### PR TITLE
fix a bad python argument name

### DIFF
--- a/org.rdkit.knime.types/python/RDKitMolDeserializer.py
+++ b/org.rdkit.knime.types/python/RDKitMolDeserializer.py
@@ -1,5 +1,5 @@
 from rdkit import Chem
 
-def deserialize(bytes):
-	return Chem.Mol(bytes)
+def deserialize(inbytes):
+	return Chem.Mol(inbytes)
 

--- a/org.rdkit.knime.types/python/RDKitReactionDeserializer.py
+++ b/org.rdkit.knime.types/python/RDKitReactionDeserializer.py
@@ -1,5 +1,5 @@
 from rdkit.Chem.rdChemReactions import ChemicalReaction
 
-def deserialize(bytes):
-	return ChemicalReaction(bytes)
+def deserialize(inbytes):
+	return ChemicalReaction(inbytes)
 


### PR DESCRIPTION
We really shouldn't have been using a Python type name (`bytes`) as a function argument name.
Fixing it was simple