### PR TITLE
Increasing version number from 3.2.2 to 3.2.3

### DIFF
--- a/org.rdkit.knime.bin.linux.x86/.settings/org.eclipse.core.resources.prefs
+++ b/org.rdkit.knime.bin.linux.x86/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.rdkit.knime.bin.linux.x86/.settings/org.eclipse.core.runtime.prefs
+++ b/org.rdkit.knime.bin.linux.x86/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/org.rdkit.knime.bin.linux.x86/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.bin.linux.x86/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDKit binaries for 32bit Linux
 Bundle-SymbolicName: org.rdkit.knime.bin.linux.x86;singleton:=true
-Bundle-Version: 3.2.2.qualifier
+Bundle-Version: 3.2.3.qualifier
 Bundle-Vendor: NIBR
-Fragment-Host: org.rdkit.knime.types;bundle-version="3.2.2"
+Fragment-Host: org.rdkit.knime.types;bundle-version="3.2.3"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Eclipse-PlatformFilter: (&(osgi.os=linux)(osgi.arch=x86))

--- a/org.rdkit.knime.bin.linux.x86_64/.settings/org.eclipse.core.resources.prefs
+++ b/org.rdkit.knime.bin.linux.x86_64/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.rdkit.knime.bin.linux.x86_64/.settings/org.eclipse.core.runtime.prefs
+++ b/org.rdkit.knime.bin.linux.x86_64/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/org.rdkit.knime.bin.linux.x86_64/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.bin.linux.x86_64/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDKit binaries for 64bit Linux
 Bundle-SymbolicName: org.rdkit.knime.bin.linux.x86_64;singleton:=true
-Bundle-Version: 3.2.2.qualifier
-Fragment-Host: org.rdkit.knime.types;bundle-version="3.2.2"
+Bundle-Version: 3.2.3.qualifier
+Fragment-Host: org.rdkit.knime.types;bundle-version="3.2.3"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Eclipse-PlatformFilter: (&(osgi.os=linux)(osgi.arch=x86_64))
 Bundle-Vendor: NIBR

--- a/org.rdkit.knime.bin.macosx.x86_64/.settings/org.eclipse.core.resources.prefs
+++ b/org.rdkit.knime.bin.macosx.x86_64/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.rdkit.knime.bin.macosx.x86_64/.settings/org.eclipse.core.runtime.prefs
+++ b/org.rdkit.knime.bin.macosx.x86_64/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/org.rdkit.knime.bin.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.bin.macosx.x86_64/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDKit binaries for 64bit MacOSX
 Bundle-SymbolicName: org.rdkit.knime.bin.macosx.x86_64;singleton:=true
-Bundle-Version: 3.2.2.qualifier
-Fragment-Host: org.rdkit.knime.types;bundle-version="3.2.2"
+Bundle-Version: 3.2.3.qualifier
+Fragment-Host: org.rdkit.knime.types;bundle-version="3.2.3"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Eclipse-PlatformFilter: (&(osgi.os=macosx)(osgi.arch=x86_64))
 Bundle-Vendor: NIBR

--- a/org.rdkit.knime.bin.win32.x86/.settings/org.eclipse.core.resources.prefs
+++ b/org.rdkit.knime.bin.win32.x86/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.rdkit.knime.bin.win32.x86/.settings/org.eclipse.core.runtime.prefs
+++ b/org.rdkit.knime.bin.win32.x86/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/org.rdkit.knime.bin.win32.x86/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.bin.win32.x86/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDKit binaries for 32bit Windows
 Bundle-SymbolicName: org.rdkit.knime.bin.win32.x86;singleton:=true
-Bundle-Version: 3.2.2.qualifier
-Fragment-Host: org.rdkit.knime.types;bundle-version="3.2.2"
+Bundle-Version: 3.2.3.qualifier
+Fragment-Host: org.rdkit.knime.types;bundle-version="3.2.3"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Eclipse-PlatformFilter: (&(osgi.os=win32)(osgi.arch=x86))
 Bundle-Vendor: NIBR

--- a/org.rdkit.knime.bin.win32.x86_64/.settings/org.eclipse.core.resources.prefs
+++ b/org.rdkit.knime.bin.win32.x86_64/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.rdkit.knime.bin.win32.x86_64/.settings/org.eclipse.core.runtime.prefs
+++ b/org.rdkit.knime.bin.win32.x86_64/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/org.rdkit.knime.bin.win32.x86_64/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.bin.win32.x86_64/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDKit binaries for 64bit Windows
 Bundle-SymbolicName: org.rdkit.knime.bin.win32.x86_64;singleton:=true
-Bundle-Version: 3.2.2.qualifier
-Fragment-Host: org.rdkit.knime.types;bundle-version="3.2.2"
+Bundle-Version: 3.2.3.qualifier
+Fragment-Host: org.rdkit.knime.types;bundle-version="3.2.3"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Eclipse-PlatformFilter: (&(osgi.os=win32)(osgi.arch=x86_64))
 Bundle-Vendor: NIBR

--- a/org.rdkit.knime.feature/.settings/org.eclipse.core.resources.prefs
+++ b/org.rdkit.knime.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.rdkit.knime.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/org.rdkit.knime.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/org.rdkit.knime.feature/feature.xml
+++ b/org.rdkit.knime.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.feature"
       label="RDKit KNIME integration"
-      version="3.2.2.qualifier"
+      version="3.2.3.qualifier"
       provider-name="NIBR"
       plugin="org.rdkit.knime.nodes">
 

--- a/org.rdkit.knime.nodes/.settings/org.eclipse.core.resources.prefs
+++ b/org.rdkit.knime.nodes/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.rdkit.knime.nodes/.settings/org.eclipse.core.runtime.prefs
+++ b/org.rdkit.knime.nodes/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/org.rdkit.knime.nodes/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.nodes/META-INF/MANIFEST.MF
@@ -2,14 +2,14 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Nodes for Knime
 Bundle-SymbolicName: org.rdkit.knime.nodes;singleton:=true
-Bundle-Version: 3.2.2.qualifier
+Bundle-Version: 3.2.3.qualifier
 Bundle-Vendor: NIBR
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui;bundle-version="[3.107.0,4.0.0)",
  org.knime.base;bundle-version="[3.2.2,4.0.0)",
  org.knime.chem.types;bundle-version="[3.2.2,4.0.0)",
  org.knime.workbench.repository;bundle-version="[3.2.1,4.0.0)",
- org.rdkit.knime.types;bundle-version="[3.2.2,4.0.0)",
+ org.rdkit.knime.types;bundle-version="[3.2.3,4.0.0)",
  org.knime.ext.svg;bundle-version="[3.2.0,4.0.0)" 
 Export-Package: org.RDKit,
  org.rdkit.knime.nodes,

--- a/org.rdkit.knime.nodes/src/org/rdkit/knime/nodes/sdfdifferencechecker/RDKitSDFDifferenceCheckerNodeModel.java
+++ b/org.rdkit.knime.nodes/src/org/rdkit/knime/nodes/sdfdifferencechecker/RDKitSDFDifferenceCheckerNodeModel.java
@@ -77,7 +77,7 @@ import org.rdkit.knime.util.SettingsUtils;
  * providing difference checks for SDF strings that take certain granted differences
  * into account.
  * 
- * @author Manuel Schwarze
+ * @author Manuel Schwarze 
  */
 public class RDKitSDFDifferenceCheckerNodeModel extends AbstractRDKitNodeModel {
 

--- a/org.rdkit.knime.nodes/src/org/rdkit/knime/nodes/sdfdifferencechecker/RDKitSDFDifferenceCheckerNodeModel.java
+++ b/org.rdkit.knime.nodes/src/org/rdkit/knime/nodes/sdfdifferencechecker/RDKitSDFDifferenceCheckerNodeModel.java
@@ -320,7 +320,7 @@ public class RDKitSDFDifferenceCheckerNodeModel extends AbstractRDKitNodeModel {
 							final double number2 = normalizeNumber(strToken2);
 
 							// Note: Integers are here also treated as NaN, because they can be string compared
-							if (number1 == Double.NaN || number2 == Double.NaN || Math.abs(number1 - number2) > dTolerance) {
+							if (Double.isNaN(number1) || Double.isNaN(number2) || Math.abs(number1 - number2) > dTolerance) {
 								recordDifference(row1, strSdf1, row2, strSdf2, "'" + strToken1 +
 										"' is different from '" + strToken2 + "'.", null, bFurtherDifferences);
 								bFurtherDifferences = true;

--- a/org.rdkit.knime.testing.feature/.settings/org.eclipse.core.resources.prefs
+++ b/org.rdkit.knime.testing.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.rdkit.knime.testing.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/org.rdkit.knime.testing.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/org.rdkit.knime.testing.feature/feature.xml
+++ b/org.rdkit.knime.testing.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.testing.feature"
       label="RDKit KNIME JUnit Test"
-      version="3.2.2.qualifier"
+      version="3.2.3.qualifier"
       provider-name="NIBR">
 
    <description>

--- a/org.rdkit.knime.testing/.settings/org.eclipse.core.resources.prefs
+++ b/org.rdkit.knime.testing/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.rdkit.knime.testing/.settings/org.eclipse.core.runtime.prefs
+++ b/org.rdkit.knime.testing/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/org.rdkit.knime.testing/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.testing/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Testing
 Bundle-SymbolicName: org.rdkit.knime.testing;singleton:=true
-Bundle-Version: 3.2.2.qualifier
-Fragment-Host: org.rdkit.knime.nodes;bundle-version="3.2.2"
+Bundle-Version: 3.2.3.qualifier
+Fragment-Host: org.rdkit.knime.nodes;bundle-version="3.2.3"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.knime.testing;bundle-version="[3.2.1,4.0.0)",
  org.knime.chem.base;bundle-version="[3.2.0,4.0.0)",

--- a/org.rdkit.knime.types/.settings/org.eclipse.core.resources.prefs
+++ b/org.rdkit.knime.types/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.rdkit.knime.types/.settings/org.eclipse.core.runtime.prefs
+++ b/org.rdkit.knime.types/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/org.rdkit.knime.types/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.types/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: rdkit-chem.jar,
  lib/org.RDKit.jar,
  lib/org.RDKitDoc.jar
-Bundle-Version: 3.2.2.qualifier
+Bundle-Version: 3.2.3.qualifier
 Bundle-Name: RDKit Chemistry Type Definition Plugin
 Bundle-Activator: org.rdkit.knime.RDKitTypesPluginActivator
 Bundle-ManifestVersion: 2

--- a/org.rdkit.knime.update/.settings/org.eclipse.core.resources.prefs
+++ b/org.rdkit.knime.update/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.rdkit.knime.update/.settings/org.eclipse.core.runtime.prefs
+++ b/org.rdkit.knime.update/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/org.rdkit.knime.update/feature.xml
+++ b/org.rdkit.knime.update/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.update"
       label="RDKit Update Site"
-      version="3.2.2.qualifier">
+      version="3.2.3.qualifier">
 
    <description url="http://www.example.com/description">
       [Enter Feature Description here.]

--- a/org.rdkit.knime.wizards.feature/.settings/org.eclipse.core.resources.prefs
+++ b/org.rdkit.knime.wizards.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.rdkit.knime.wizards.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/org.rdkit.knime.wizards.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/org.rdkit.knime.wizards.feature/feature.xml
+++ b/org.rdkit.knime.wizards.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.wizards.feature"
       label="RDKit KNIME Wizards"
-      version="3.2.2.qualifier"
+      version="3.2.3.qualifier"
       provider-name="NIBR"
       plugin="org.rdkit.knime.wizards">
 

--- a/org.rdkit.knime.wizards.samples/.settings/org.eclipse.core.resources.prefs
+++ b/org.rdkit.knime.wizards.samples/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.rdkit.knime.wizards.samples/.settings/org.eclipse.core.runtime.prefs
+++ b/org.rdkit.knime.wizards.samples/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/org.rdkit.knime.wizards.samples/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.wizards.samples/META-INF/MANIFEST.MF
@@ -2,13 +2,13 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Node Wizards Samples
 Bundle-SymbolicName: org.rdkit.knime.wizards.samples;singleton:=true
-Bundle-Version: 3.2.2.qualifier
+Bundle-Version: 3.2.3.qualifier
 Bundle-Activator: org.rdkit.knime.wizards.samples.Activator
 Bundle-Vendor: NIBR
 Require-Bundle: org.knime.base;bundle-version="3.2.2",
  org.knime.chem.types;bundle-version="3.2.2",
- org.rdkit.knime.nodes;bundle-version="3.2.1",
- org.rdkit.knime.types;bundle-version="3.2.1",
+ org.rdkit.knime.nodes;bundle-version="3.2.3",
+ org.rdkit.knime.types;bundle-version="3.2.3",
  org.eclipse.ui;bundle-version="3.107.0",
  org.eclipse.core.runtime;bundle-version="3.11.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.rdkit.knime.wizards/.settings/org.eclipse.core.resources.prefs
+++ b/org.rdkit.knime.wizards/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.rdkit.knime.wizards/.settings/org.eclipse.core.runtime.prefs
+++ b/org.rdkit.knime.wizards/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/org.rdkit.knime.wizards/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.wizards/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Nodes Wizards
 Bundle-SymbolicName: org.rdkit.knime.wizards;singleton:=true
-Bundle-Version: 3.2.2.qualifier
+Bundle-Version: 3.2.3.qualifier
 Bundle-Activator: org.rdkit.knime.wizards.RDKitNodesWizardsPlugin
 Bundle-Vendor: NIBR
 Require-Bundle: org.knime.base;bundle-version="[3.2.2,4.0.0)",


### PR DESCRIPTION
This branch contains also a tiny bugfix. Unfortunately, again my committed file is shown as if the entire Java file was changed although only one single line was changed. On the other site all the Manifest files show their line changes correctly. If somebody knows what to do about that for the future, please let me know - it is really annoying.

Testing Results for new RDKit Binaries:
KNIME 3.3
- [x] Windows 32-bit
- [x] Windows 64-bit
- [x] Linux 32-bit
- [x] Linux 64-bit
- [x] Mac 64-bit

