### PR TITLE
Adapted version number consistently to 4.0.0

### DIFF
--- a/org.rdkit.knime.feature/feature.xml
+++ b/org.rdkit.knime.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.feature"
       label="RDKit KNIME integration"
-      version="3.8.0.qualifier"
+      version="4.0.0.qualifier"
       provider-name="NIBR"
       plugin="org.rdkit.knime.nodes">
 

--- a/org.rdkit.knime.nodes/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.nodes/META-INF/MANIFEST.MF
@@ -3,14 +3,14 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Nodes for Knime
 Bundle-SymbolicName: org.rdkit.knime.nodes;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.nodes
-Bundle-Version: 3.8.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Vendor: NIBR
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui;bundle-version="[3.109.0,4.0.0)",
  org.knime.base;bundle-version="[3.6.2,5.0.0)",
  org.knime.chem.types;bundle-version="[3.6.0,5.0.0)",
  org.knime.workbench.repository;bundle-version="[3.6.0,5.0.0)",
- org.rdkit.knime.types;bundle-version="[3.8.0,5.0.0)",
+ org.rdkit.knime.types;bundle-version="[4.0.0,5.0.0)",
  org.knime.ext.svg;bundle-version="[3.6.2,5.0.0)"
 Export-Package: org.rdkit.knime.nodes,
  org.rdkit.knime.nodes.addconformers,

--- a/org.rdkit.knime.testing.feature/feature.xml
+++ b/org.rdkit.knime.testing.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.testing.feature"
       label="RDKit KNIME JUnit Test"
-      version="3.8.0.qualifier"
+      version="4.0.0.qualifier"
       provider-name="NIBR">
 
    <description>

--- a/org.rdkit.knime.testing/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.testing/META-INF/MANIFEST.MF
@@ -3,8 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Testing
 Bundle-SymbolicName: org.rdkit.knime.testing;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.testing
-Bundle-Version: 3.8.0.qualifier
-Fragment-Host: org.rdkit.knime.nodes;bundle-version="3.8.0"
+Bundle-Version: 4.0.0.qualifier
+Fragment-Host: org.rdkit.knime.nodes;bundle-version="4.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.knime.testing;bundle-version="[3.7.0,5.0.0)",
  org.knime.chem.base;bundle-version="[3.6.0,5.0.0)",

--- a/org.rdkit.knime.update/feature.xml
+++ b/org.rdkit.knime.update/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.update"
       label="RDKit Update Site"
-      version="3.8.0.qualifier">
+      version="4.0.0.qualifier">
 
    <description url="http://www.example.com/description">
       [Enter Feature Description here.]

--- a/org.rdkit.knime.wizards.feature/feature.xml
+++ b/org.rdkit.knime.wizards.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.wizards.feature"
       label="RDKit KNIME Wizards"
-      version="3.8.0.qualifier"
+      version="4.0.0.qualifier"
       provider-name="NIBR"
       plugin="org.rdkit.knime.wizards">
 

--- a/org.rdkit.knime.wizards.samples/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.wizards.samples/META-INF/MANIFEST.MF
@@ -3,13 +3,13 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Node Wizards Samples
 Bundle-SymbolicName: org.rdkit.knime.wizards.samples;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.wizards.samples
-Bundle-Version: 3.8.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Activator: org.rdkit.knime.wizards.samples.Activator
 Bundle-Vendor: NIBR
 Require-Bundle: org.knime.base;bundle-version="[3.6.2,5.0.0)",
  org.knime.chem.types;bundle-version="[3.6.0,5.0.0)",
- org.rdkit.knime.nodes;bundle-version="[3.8.0,4.0.0)",
- org.rdkit.knime.types;bundle-version="[3.8.0,4.0.0)",
+ org.rdkit.knime.nodes;bundle-version="[4.0.0,5.0.0)",
+ org.rdkit.knime.types;bundle-version="[4.0.0,5.0.0)",
  org.eclipse.ui;bundle-version="[3.109.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.13.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.rdkit.knime.wizards/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.wizards/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Nodes Wizards
 Bundle-SymbolicName: org.rdkit.knime.wizards;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.wizards
-Bundle-Version: 3.8.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Activator: org.rdkit.knime.wizards.RDKitNodesWizardsPlugin
 Bundle-Vendor: NIBR
 Require-Bundle: org.knime.base;bundle-version="[3.6.2,5.0.0)",


### PR DESCRIPTION
Versions of all RDKit node components (binaries, types, nodes, tests,
wizards) should all be in sync to have clarity what belongs together.