### PR TITLE
simplify reaction copy in ChemicalTransformation node

### DIFF
--- a/org.rdkit.knime.nodes/src/org/rdkit/knime/nodes/chemicaltransformation/RDKitChemicalTransformationNodeModel.java
+++ b/org.rdkit.knime.nodes/src/org/rdkit/knime/nodes/chemicaltransformation/RDKitChemicalTransformationNodeModel.java
@@ -516,12 +516,7 @@ public class RDKitChemicalTransformationNodeModel extends AbstractRDKitCalculato
 				final ChemicalReaction[] arrCopy = new ChemicalReaction[m_arrReactions.length];
 
 				for (int i = 0; i < m_arrReactions.length; i++) {
-					if (m_bIsSmartsInput) {
-						arrCopy[i] = markForCleanup(ChemicalReaction.ReactionFromSmarts(ChemicalReaction.ReactionToSmarts(m_arrReactions[i])));
-					}
-					else {
-						arrCopy[i] = markForCleanup(ChemicalReaction.ReactionFromRxnBlock(ChemicalReaction.ReactionToRxnBlock(m_arrReactions[i])));
-					}
+					arrCopy[i] = markForCleanup(new ChemicalReaction(m_arrReactions[i]));
 				}
 
 				return arrCopy;


### PR DESCRIPTION
The code to copy reactions in the ChemicalTransformation nodes was doing too much work.
This modifies that to use a simple copy constructor.