### PR TITLE
Enable multibranch builds with Jenkins (KNIME-1023, for NIBR internal development only)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,9 +7,9 @@ pipeline {
 
     environment {
     	M2_HOME=/apps/knime/buildtools/apache-maven
-		PATH=${M2_HOME}/bin:${PATH}
+		PATH=$M2_HOME/bin:$PATH
     	KNIME_VERSION = "4.3"
-    	UPDATE_SITE = "http://chbs-knime-app.tst.nibr.novartis.net/${KNIME_VERSION}/update/mirror"
+    	UPDATE_SITE = "http://chbs-knime-app.tst.nibr.novartis.net/$KNIME_VERSION/update/mirror"
     	QUALIFIER_PREFIX = "vnibr"
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,12 +30,14 @@ pipeline {
         }
         stage('Installing Test Instance') {
         	steps {
-				        		
+				// Output environment
+				sh "env"
         	}
         } 
         stage('Running Tests') {
         	steps {
-        		
+				// Output environment
+				sh "env"
         	}
         } 
         stage('Deploying to Update Site') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,9 @@ pipeline {
         	steps {
 				// Output environment
 				sh "env"
+				
+				// Cleanup old data
+				sh "rm -rf tmp results"
 	
 	            // Compiles the plugin and builds an update site from it
 		        configFileProvider([configFile(fileId: 'artifactory-maven-settings', variable: 'MAVEN_SETTINGS')]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,10 +44,13 @@ pipeline {
 				// Output environment
 				sh '''#!/bin/bash
 					cd "${WORKSPACE}"
-					ln -s "${DIRECTOR_HOME}" "./scripts/knime-community/director"
+					ln -sf "${DIRECTOR_HOME}" "./scripts/knime-community/director"
 					source ./scripts/knime-community/community.inc			
 					export LC_NUMERIC=en_US.UTF-8
 					export RELEASE_REPOS="${UPDATE_SITE}"
+					# "Setup virtual X-Server ..."
+					Xvfb :$$ -fp "/usr/share/X11/fonts/misc" -fbdir "${tempDirectory}" &
+					export DISPLAY=:$$
 					runTests file://${WORKSPACE}/org.rdkit.knime.update/target/repository Testflows/${JOB_NAME##*-}/RDKit "${WORKSPACE}/org.rdkit.knime.testing/regression-tests/zips"
 				'''
         	}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,7 +94,7 @@ pipeline {
 					if (env.git_branch_lowercase == 'master' || env.GIT_BRANCH == 'master') {
 						// Add successfully tested RDKit artifacts to existing NIBR update site
 						sh '''
-							"${WORKSPACE}/scripts/mirrorSingleUpdateSite.sh" "${WORKSPACE}/tmp/knime\ test/knime" "${DEPLOY_MASTER_UPDATE_SITE}" true true "${WORKSPACE}/scripts/mirror.xml" "${WORKSPACE}/org.rdkit.knime.update/target/repository/"
+							"${WORKSPACE}/scripts/mirrorSingleUpdateSite.sh" "${WORKSPACE}/tmp/knime test/knime" "${DEPLOY_MASTER_UPDATE_SITE}" true true "${WORKSPACE}/scripts/mirror.xml" "${WORKSPACE}/org.rdkit.knime.update/target/repository/"
 						'''
 					} 
 					else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
     	UPDATE_SITE = "http://chbs-knime-app.tst.nibr.novartis.net/${KNIME_VERSION}/update/mirror"
     	
     	// Define extra IUs to be installed for running test workflows (used by community.inc methods)
-    	EXTRA_IUs = "" 
+    	EXTRA_IUs = "org.knime.features.core.streaming.feature.group" 
     	
     	// Defines how tests are performed - this is passed in addition to the runTests method, which internally calls
     	// the KNIME org.knime.testing.NGTestflowRunner application, which comes with the org.knime.features.testing.application feature.
@@ -61,7 +61,7 @@ pipeline {
 		//     -streaming: optional, enables additional streaming test for workflows configured accordingly. The test streaming job manager is set and used for each single node.
 		//     -preferences <file_name>: optional, specifies an exported preferences file that should be used to initialize preferences
 		//     -workflow.variable <variable-declaration>: optional, defines or overwrites workflow variable 'name' with value 'value' (possibly enclosed by quotes). The 'type' must be one of "String", "int" or "double".
-    	TEST_DEPTH_PARAMS = "-loadSaveLoad -views -dialogs -logMessages -streaming -stacktraceOnTimeout"
+    	TEST_DEPTH_PARAMS = "-loadSaveLoad -views -logMessages -streaming -stacktraceOnTimeout"
     	
     	// Target update sites to use when everything was tested successfully to deploy the build artifacts
     	DEPLOY_MASTER_UPDATE_SITE = "/apps/knime/web/${KNIME_VERSION}/update/nibr"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ pipeline {
 						sh '''
 							rm -rf "${DEPLOY_BRANCH_UPDATE_SITE}/${BRANCH_NAME}"
 							mkdir -p "${DEPLOY_BRANCH_UPDATE_SITE}/${BRANCH_NAME}"
-							mv -f "${WORKSPACE}/org.rdkit.knime.update/target/repository/*" "${DEPLOY_BRANCH_UPDATE_SITE}/${BRANCH_NAME}/"
+							mv -f "${WORKSPACE}/org.rdkit.knime.update/target/repository"/* "${DEPLOY_BRANCH_UPDATE_SITE}/${BRANCH_NAME}/"
 						'''
 					}
 		        }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,12 +16,8 @@ pipeline {
     stages {
 	    stage('GitCheckout') {
 	        steps {
-				dir("${WORKSPACE}/org.rdkit") {
-          			checkout([$class: 'GitSCM', branches: [[name: 'refs/heads/${BRANCH_NAME}']], doGenerateSubmoduleConfigurations: false, \
-          			extensions: [], gitTool: 'default-git', submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'bitbucket-jenkins', \
-          			url: "https://bitbucket.prd.nibr.novartis.net/scm/knim/knime-rdkit.git"]]])
-        		}
-				dir("${WORKSPACE}/scripts") {
+	        	checkout scm
+				dir("scripts") {
 					// TODO: Change to refs/heads/master
           			checkout([$class: 'GitSCM', branches: [[name: 'refs/heads/KNIME-1023_Setup_maven_as_build_tool']], doGenerateSubmoduleConfigurations: false, \
           			extensions: [], gitTool: 'default-git', submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'bitbucket-jenkins', \
@@ -35,11 +31,9 @@ pipeline {
 				sh "env"
 	
 	            // Compiles the plugin and builds an update site from it
-	            dir('org.rdkit') {
-			        configFileProvider([configFile(fileId: 'artifactory-maven-settings', variable: 'MAVEN_SETTINGS')]) {
-		              sh(label: "Compile and Build", script: "mvn -U clean verify -Dupdate.site=${UPDATE_SITE} -Dqualifier.prefix=${QUALIFIER_PREFIX} -s ${MAVEN_SETTINGS}")
-			        }
-			    }
+		        configFileProvider([configFile(fileId: 'artifactory-maven-settings', variable: 'MAVEN_SETTINGS')]) {
+	              sh(label: "Compile and Build", script: "mvn -U clean verify -Dupdate.site=${UPDATE_SITE} -Dqualifier.prefix=${QUALIFIER_PREFIX} -s ${MAVEN_SETTINGS}")
+		        }
 		    }    
         }
         stage('Installing Test Instance') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,8 @@ pipeline {
     }
 
     environment {
+    	M2_HOME=/apps/knime/buildtools/apache-maven
+		PATH=${M2_HOME}/bin:${PATH}
     	KNIME_VERSION = "4.3"
     	UPDATE_SITE = "http://chbs-knime-app.tst.nibr.novartis.net/${KNIME_VERSION}/update/mirror"
     	QUALIFIER_PREFIX = "vnibr"
@@ -13,16 +15,25 @@ pipeline {
 
     stages {
         stage('Compile and Build') {
-            steps {
-                // Get code from BitBucket repository
-                checkout scm
+	        script {
+	          if (env.git_branch_lowercase == 'master' || env.GIT_BRANCH == 'master') {
+	            env.target = 'deploy'
+	          } 
+	          else {
+	            env.target = 'package'
+	          }
+	        }
 
-				// Output environment
-				sh "env"
+            // Get code from BitBucket repository
+            checkout scm
 
-                // Compiles the plugin and builds an update site from it
-                sh "mvn -U clean verify -Dupdate.site=${UPDATE_SITE} -Dqualifier.prefix=$QUALIFIER_PREFIX"
-            }
+			// Output environment
+			sh "env"
+
+            // Compiles the plugin and builds an update site from it
+	        configFileProvider([configFile(fileId: 'artifactory-maven-settings', variable: 'MAVEN_SETTINGS')]) {
+              sh(label: "Compile and Build", script: "mvn -U clean verify -Dupdate.site=$UPDATE_SITE -Dqualifier.prefix=$QUALIFIER_PREFIX -s $MAVEN_SETTINGS")
+	        }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
         stage('Running Tests') {
         	steps {
 				// Output environment
-				sh '''
+				sh '''#!/bin/bash
 					cd "${WORKSPACE}"
 					source ./scripts/community.inc			
 					export LC_NUMERIC=en_US.UTF-8

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,28 @@
+pipeline {
+    agent {
+        node {
+            label 'knime-test-basel-c7'
+        }
+    }
+
+    environment {
+    	KNIME_VERSION = "4.3"
+    	UPDATE_SITE = "http://chbs-knime-app.tst.nibr.novartis.net/${KNIME_VERSION}/update/mirror"
+    	QUALIFIER_PREFIX = "vnibr"
+    }
+
+    stages {
+        stage('Compile and Build') {
+            steps {
+                // Get code from BitBucket repository
+                checkout scm
+
+				// Output environment
+				sh "env"
+
+                // Compiles the plugin and builds an update site from it
+                sh "mvn -U clean verify -Dupdate.site=${UPDATE_SITE} -Dqualifier.prefix=$QUALIFIER_PREFIX"
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,24 +6,15 @@ pipeline {
     }
 
     environment {
-    	M2_HOME=/apps/knime/buildtools/apache-maven
-		PATH=$M2_HOME/bin:$PATH
+    	M2_HOME = "/apps/knime/buildtools/apache-maven"
+		PATH = "${M2_HOME}/bin:${PATH}"
     	KNIME_VERSION = "4.3"
-    	UPDATE_SITE = "http://chbs-knime-app.tst.nibr.novartis.net/$KNIME_VERSION/update/mirror"
+    	UPDATE_SITE = "http://chbs-knime-app.tst.nibr.novartis.net/${KNIME_VERSION}/update/mirror"
     	QUALIFIER_PREFIX = "vnibr"
     }
 
     stages {
         stage('Compile and Build') {
-	        script {
-	          if (env.git_branch_lowercase == 'master' || env.GIT_BRANCH == 'master') {
-	            env.target = 'deploy'
-	          } 
-	          else {
-	            env.target = 'package'
-	          }
-	        }
-
             // Get code from BitBucket repository
             checkout scm
 
@@ -32,8 +23,19 @@ pipeline {
 
             // Compiles the plugin and builds an update site from it
 	        configFileProvider([configFile(fileId: 'artifactory-maven-settings', variable: 'MAVEN_SETTINGS')]) {
-              sh(label: "Compile and Build", script: "mvn -U clean verify -Dupdate.site=$UPDATE_SITE -Dqualifier.prefix=$QUALIFIER_PREFIX -s $MAVEN_SETTINGS")
+              sh(label: "Compile and Build", script: "mvn -U clean verify -Dupdate.site=${UPDATE_SITE} -Dqualifier.prefix=${QUALIFIER_PREFIX} -s ${MAVEN_SETTINGS}")
 	        }
         }
+        stage('Installing Test Instance') {
+        
+        } 
+        stage('Running Tests') {
+        
+        } 
+        stage('Deploying to Update Site') {
+        	if (env.git_branch_lowercase == 'master' || env.GIT_BRANCH == 'master') {
+        		
+        	}
+        } 
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,6 @@ pipeline {
 	                         url: 'https://bitbucket.prd.nibr.novartis.net/scm/knim/knime-rdkit.git'  \
 	                     ]]
 	                ]
-	            ]
 	            checkout \
 	                scm: [ $class : 'GitSCM', \
 	                     branches: [[name: 'refs/heads/KNIME-1023_Setup_maven_as_build_tool']], \
@@ -34,7 +33,6 @@ pipeline {
 	                         url: 'https://bitbucket.prd.nibr.novartis.net/scm/knim/knime-build-scripts.git'  \
 	                     ]]
 	                ]
-	            ]
 	        }
 	    }    
         stage('Compile and Build') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         node {
-        	// This job needs to run on the KNIME server that hosts also the target update site 
+            // This job needs to run on the KNIME server that hosts also the target update site 
             label 'knime-test-basel-c7'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,8 @@ pipeline {
 						// Deploy resulting build artifacts as review update (overriding an existing one)
 						sh '''
 							rm -rf "${DEPLOY_BRANCH_UPDATE_SITE}/${BRANCH_NAME}"
-							mv "${WORKSPACE}/org.rdkit.knime.update/target/repository" "${DEPLOY_BRANCH_UPDATE_SITE}/${BRANCH_NAME}"
+							mkdir -p "${DEPLOY_BRANCH_UPDATE_SITE}/${BRANCH_NAME}"
+							mv -f "${WORKSPACE}/org.rdkit.knime.update/target/repository/*" "${DEPLOY_BRANCH_UPDATE_SITE}/${BRANCH_NAME}/"
 						'''
 					}
 		        }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,10 +48,7 @@ pipeline {
 					source ./scripts/knime-community/community.inc			
 					export LC_NUMERIC=en_US.UTF-8
 					export RELEASE_REPOS="${UPDATE_SITE}"
-					# "Setup virtual X-Server ..."
-					Xvfb :$$ -fp "/usr/share/X11/fonts/misc" -fbdir "${tempDirectory}" &
-					export DISPLAY=:$$
-					runTests file://${WORKSPACE}/org.rdkit.knime.update/target/repository Testflows/${JOB_NAME##*-}/RDKit "${WORKSPACE}/org.rdkit.knime.testing/regression-tests/zips"
+					runTests file://${WORKSPACE}/org.rdkit.knime.update/target/repository "noServerAccess" "${WORKSPACE}/org.rdkit.knime.testing/regression-tests/zips"
 				'''
         	}
             post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,16 +15,18 @@ pipeline {
 
     stages {
         stage('Compile and Build') {
-            // Get code from BitBucket repository
-            checkout scm
-
-			// Output environment
-			sh "env"
-
-            // Compiles the plugin and builds an update site from it
-	        configFileProvider([configFile(fileId: 'artifactory-maven-settings', variable: 'MAVEN_SETTINGS')]) {
-              sh(label: "Compile and Build", script: "mvn -U clean verify -Dupdate.site=${UPDATE_SITE} -Dqualifier.prefix=${QUALIFIER_PREFIX} -s ${MAVEN_SETTINGS}")
-	        }
+        	steps {
+	            // Get code from BitBucket repository
+	            checkout scm
+	
+				// Output environment
+				sh "env"
+	
+	            // Compiles the plugin and builds an update site from it
+		        configFileProvider([configFile(fileId: 'artifactory-maven-settings', variable: 'MAVEN_SETTINGS')]) {
+	              sh(label: "Compile and Build", script: "mvn -U clean verify -Dupdate.site=${UPDATE_SITE} -Dqualifier.prefix=${QUALIFIER_PREFIX} -s ${MAVEN_SETTINGS}")
+		        }
+		    }    
         }
         stage('Installing Test Instance') {
         
@@ -33,9 +35,16 @@ pipeline {
         
         } 
         stage('Deploying to Update Site') {
-        	if (env.git_branch_lowercase == 'master' || env.GIT_BRANCH == 'master') {
-        		
-        	}
+			steps {
+		        script {
+		          if (env.git_branch_lowercase == 'master' || env.GIT_BRANCH == 'master') {
+	
+		          } 
+		          else {
+	
+		          }
+		        }
+		    }
         } 
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,41 +1,64 @@
 pipeline {
     agent {
         node {
+        	// This job needs to run on the KNIME server that hosts also the target update site 
             label 'knime-test-basel-c7'
         }
     }
 
     environment {
+    	// Two pre-requisites that need to be installed by the NIBR Jenkins job knime4.x-all-setup-build-environment
     	DIRECTOR_HOME = "/apps/knime/buildtools/director"
     	M2_HOME = "/apps/knime/buildtools/apache-maven"
 		PATH = "${M2_HOME}/bin:${PATH}"
+		
+		// Scripts required for testing and deployment
+		GIT_REPO_SCRIPTS = "https://bitbucket.prd.nibr.novartis.net/scm/knim/knime-build-scripts.git"
+		// TODO: Change to refs/heads/master
+        GIT_BRANCH_SCRIPTS = "refs/heads/KNIME-1023_Setup_maven_as_build_tool"
+		
+		// A feature (branch or master) should always be built for one specific KNIME version only
     	KNIME_VERSION = "4.3"
+    	
+    	// Prefix for the version number of the artifacts to distinguish them from normal community builds 
+    	// (vnibrYYYYMMDDHHSS always is considered a higher version than a community built version vYYYYMMDDHHSS)
+    	QUALIFIER_PREFIX = "vnibr"
+    	
+    	// Source update site used for building the KNIME Test Instance for regression testing
     	UPDATE_SITE = "http://chbs-knime-app.tst.nibr.novartis.net/${KNIME_VERSION}/update/mirror"
+    	
+    	// Target update sites to use when everything was tested successfully to deploy the build artifacts
     	DEPLOY_MASTER_UPDATE_SITE = "/apps/knime/web/${KNIME_VERSION}/update/nibr"
     	DEPLOY_BRANCH_UPDATE_SITE = "/apps/knime/web/${KNIME_VERSION}/update/knime-rdkit-review"
-    	QUALIFIER_PREFIX = "vnibr"
     }
 
     stages {
 	    stage('GitCheckout') {
 	        steps {
+	        	// Get the branch that triggered this build 
 	        	checkout scm
+	        	
+	        	// In addition get scripts required for testing and deployment
+	        	// They will be checked out into a scripts directory, which resides within the root directory of the main checkout,
+	        	// which is sub-optimal, but no other solution was found so far
 				dir("scripts") {
-					// TODO: Change to refs/heads/master
-          			checkout([$class: 'GitSCM', branches: [[name: 'refs/heads/KNIME-1023_Setup_maven_as_build_tool']], doGenerateSubmoduleConfigurations: false, \
+					checkout([$class: 'GitSCM', branches: [[name: '${GIT_BRANCH_SCRIPTS}']], doGenerateSubmoduleConfigurations: false, \
           			extensions: [], gitTool: 'default-git', submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'bitbucket-jenkins', \
-          			url: "https://bitbucket.prd.nibr.novartis.net/scm/knim/knime-build-scripts.git"]]])
+          			url: "${GIT_REPO_SCRIPTS}"]]])
         		}
 	        }
-	    }    
-        stage('Compile and Build') {
+	    }   
+	    stage('Cleanup') {
         	steps {
 				// Output environment
 				sh "env"
 				
 				// Cleanup old data
 				sh "rm -rf tmp results"
-	
+			}
+		}	 
+        stage('Compile and Build') {
+        	steps {
 	            // Compiles the plugin and builds an update site from it
 		        configFileProvider([configFile(fileId: 'artifactory-maven-settings', variable: 'MAVEN_SETTINGS')]) {
 					sh(label: "Compile and Build", script: "mvn -U clean verify -Dupdate.site=${UPDATE_SITE} -Dqualifier.prefix=${QUALIFIER_PREFIX} -s ${MAVEN_SETTINGS}")
@@ -44,11 +67,14 @@ pipeline {
         }
         stage('Running Tests') {
         	steps {
-				// Output environment
+				// Installs with the Director tool a new minimal KNIME instance with the build artifacts (needs to run as bash script!)
+				// The logic comes from the KNIME Community implementation (community.inc), which was slightly adapted to disable
+				// accessing the KNIME Community server for test workflows, because we provide those as part of the RDKit testing feature
+				// and cannot access the server from NIBR (proxy settings and credentials would be required for authentication)
 				sh '''#!/bin/bash
 					cd "${WORKSPACE}"
 					ln -sf "${DIRECTOR_HOME}" "./scripts/knime-community/director"
-					source ./scripts/knime-community/community.inc			
+					source ./scripts/knime-community/community.inc
 					export LC_NUMERIC=en_US.UTF-8
 					export RELEASE_REPOS="${UPDATE_SITE}"
 					runTests file://${WORKSPACE}/org.rdkit.knime.update/target/repository "noServerAccess" "${WORKSPACE}/org.rdkit.knime.testing/regression-tests/zips"
@@ -66,10 +92,17 @@ pipeline {
 			steps {
 		        script {
 					if (env.git_branch_lowercase == 'master' || env.GIT_BRANCH == 'master') {
-						
+						// Add successfully tested RDKit artifacts to existing NIBR update site
+						sh '''
+							"${WORKSPACE}/scripts/mirrorSingleUpdateSite.sh" \
+								"${WORKSPACE}/tmp/knime\ test/knime" \
+								"${DEPLOY_MASTER_UPDATE_SITE}" true true \
+								"${WORKSPACE}/scripts/mirror.xml" \
+								"${WORKSPACE}/org.rdkit.knime.update/target/repository/"
+						'''
 					} 
 					else {
-						// Deploy resulting build artifacts as review update (overriding an existing one)
+						// Deploy resulting build artifacts of branches as review update with the branch name only (overriding an existing one)
 						sh '''
 							rm -rf "${DEPLOY_BRANCH_UPDATE_SITE}/${BRANCH_NAME}"
 							mkdir -p "${DEPLOY_BRANCH_UPDATE_SITE}/${BRANCH_NAME}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,18 +14,40 @@ pipeline {
     }
 
     stages {
+	    stage('GitCheckout') {
+	        steps {
+	            checkout \
+	                scm: [ $class : 'GitSCM', \
+	                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'org.rdkit']],
+	                                 [ $class: 'ScmName', name: 'rdkit-git' ]], \
+	                     userRemoteConfigs: [[ \
+	                         url: 'https://bitbucket.prd.nibr.novartis.net/scm/knim/knime-rdkit.git'  \
+	                     ]]
+	                ]
+	            ]
+	            checkout \
+	                scm: [ $class : 'GitSCM', \
+	                     branches: [[name: 'refs/heads/KNIME-1023_Setup_maven_as_build_tool']], \
+	                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'scripts']],
+	                                 [ $class: 'ScmName', name: 'scripts' ]], \
+	                     userRemoteConfigs: [[ \
+	                         url: 'https://bitbucket.prd.nibr.novartis.net/scm/knim/knime-build-scripts.git'  \
+	                     ]]
+	                ]
+	            ]
+	        }
+	    }    
         stage('Compile and Build') {
         	steps {
-	            // Get code from BitBucket repository
-	            checkout scm
-	
 				// Output environment
 				sh "env"
 	
 	            // Compiles the plugin and builds an update site from it
-		        configFileProvider([configFile(fileId: 'artifactory-maven-settings', variable: 'MAVEN_SETTINGS')]) {
-	              sh(label: "Compile and Build", script: "mvn -U clean verify -Dupdate.site=${UPDATE_SITE} -Dqualifier.prefix=${QUALIFIER_PREFIX} -s ${MAVEN_SETTINGS}")
-		        }
+	            dir('org.rdkit') {
+			        configFileProvider([configFile(fileId: 'artifactory-maven-settings', variable: 'MAVEN_SETTINGS')]) {
+		              sh(label: "Compile and Build", script: "mvn -U clean verify -Dupdate.site=${UPDATE_SITE} -Dqualifier.prefix=${QUALIFIER_PREFIX} -s ${MAVEN_SETTINGS}")
+			        }
+			    }
 		    }    
         }
         stage('Installing Test Instance') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
     }
 
     environment {
+    	DIRECTOR_HOME = "/apps/knime/buildtools/director"
     	M2_HOME = "/apps/knime/buildtools/apache-maven"
 		PATH = "${M2_HOME}/bin:${PATH}"
     	KNIME_VERSION = "4.3"
@@ -43,7 +44,8 @@ pipeline {
 				// Output environment
 				sh '''#!/bin/bash
 					cd "${WORKSPACE}"
-					source ./scripts/community.inc			
+					ln -s "${DIRECTOR_HOME}" "./scripts/knime-community/director"
+					source ./scripts/knime-community/community.inc			
 					export LC_NUMERIC=en_US.UTF-8
 					export RELEASE_REPOS="${UPDATE_SITE}"
 					runTests file://${WORKSPACE}/org.rdkit.knime.update/target/repository Testflows/${JOB_NAME##*-}/RDKit "${WORKSPACE}/org.rdkit.knime.testing/regression-tests/zips"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -235,7 +235,7 @@ pipeline {
 			steps {
 				build job: "/KNIME/knime${env.KNIME_VERSION}-${env.ENVIRONMENT}-package-linux", 
 					  parameters: [string(name: "ENVIRONMENT", value: "${env.ENVIRONMENT}"), 
-								 string(name: "MIRROR_UPDATE_SITE_URL", value: "${env.PRIMARY_UPDATE_SITE}"), 
+								 string(name: "MIRROR_UPDATE_SITE_URL", value: "${env.UPDATE_SITE}"), 
 								 string(name: "NIBR_UPDATE_SITE_URL", value: "${env.MASTER_UPDATE_SITE_URL}")],
 					  quietPeriod: 0, 
 					  wait: false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,23 +16,17 @@ pipeline {
     stages {
 	    stage('GitCheckout') {
 	        steps {
-	            checkout \
-	                scm: [ $class : 'GitSCM', \
-	                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'org.rdkit'],
-	                                  [$class: 'ScmName', name: 'rdkit-git' ]], \
-	                     userRemoteConfigs: [[ \
-	                         url: 'https://bitbucket.prd.nibr.novartis.net/scm/knim/knime-rdkit.git'  \
-	                     ]]
-	                ]
-	            checkout \
-	                scm: [ $class : 'GitSCM', \
-	                     branches: [[name: 'refs/heads/KNIME-1023_Setup_maven_as_build_tool']], \
-	                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'scripts'],
-	                                  [$class: 'ScmName', name: 'scripts' ]], \
-	                     userRemoteConfigs: [[ \
-	                         url: 'https://bitbucket.prd.nibr.novartis.net/scm/knim/knime-build-scripts.git'  \
-	                     ]]
-	                ]
+				dir("${WORKSPACE}/org.rdkit") {
+          			checkout([$class: 'GitSCM', branches: [[name: 'refs/heads/${BRANCH_NAME}']], doGenerateSubmoduleConfigurations: false, \
+          			extensions: [], gitTool: 'default-git', submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'bitbucket-jenkins', \
+          			url: "https://bitbucket.prd.nibr.novartis.net/scm/knim/knime-rdkit.git"]]])
+        		}
+				dir("${WORKSPACE}/scripts") {
+					// TODO: Change to refs/heads/master
+          			checkout([$class: 'GitSCM', branches: [[name: 'refs/heads/KNIME-1023_Setup_maven_as_build_tool']], doGenerateSubmoduleConfigurations: false, \
+          			extensions: [], gitTool: 'default-git', submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'bitbucket-jenkins', \
+          			url: "https://bitbucket.prd.nibr.novartis.net/scm/knim/knime-build-scripts.git"]]])
+        		}
 	        }
 	    }    
         stage('Compile and Build') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,9 @@ pipeline {
     	// Source update site used for building the KNIME Test Instance for regression testing
     	UPDATE_SITE = "http://chbs-knime-app.tst.nibr.novartis.net/${KNIME_VERSION}/update/mirror"
     	
+    	// Define extra IUs to be installed for running test workflows (used by community.inc methods)
+    	EXTRA_IUs = "" 
+    	
     	// Defines how tests are performed - this is passed in addition to the runTests method, which internally calls
     	// the KNIME org.knime.testing.NGTestflowRunner application, which comes with the org.knime.features.testing.application feature.
     	// To see an output of valid arguments like the following, specify an invalid argument.
@@ -116,7 +119,7 @@ pipeline {
 					}
 					export LC_NUMERIC=en_US.UTF-8
 					export RELEASE_REPOS="${UPDATE_SITE}"
-					runTests file://${WORKSPACE}/org.rdkit.knime.update/target/repository "noServerAccess" "${WORKSPACE}/org.rdkit.knime.testing/regression-tests/zips" ${TEST_DEPTH_PARAMS}
+					runTests file://${WORKSPACE}/org.rdkit.knime.update/target/repository "noServerAccess" "${WORKSPACE}/org.rdkit.knime.testing/regression-tests/zips" "" "${TEST_DEPTH_PARAMS}"
 				'''
         	}
             post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,8 +18,8 @@ pipeline {
 	        steps {
 	            checkout \
 	                scm: [ $class : 'GitSCM', \
-	                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'org.rdkit']],
-	                                 [ $class: 'ScmName', name: 'rdkit-git' ]], \
+	                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'org.rdkit'],
+	                                  [$class: 'ScmName', name: 'rdkit-git' ]], \
 	                     userRemoteConfigs: [[ \
 	                         url: 'https://bitbucket.prd.nibr.novartis.net/scm/knim/knime-rdkit.git'  \
 	                     ]]
@@ -27,8 +27,8 @@ pipeline {
 	            checkout \
 	                scm: [ $class : 'GitSCM', \
 	                     branches: [[name: 'refs/heads/KNIME-1023_Setup_maven_as_build_tool']], \
-	                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'scripts']],
-	                                 [ $class: 'ScmName', name: 'scripts' ]], \
+	                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'scripts'],
+	                                  [$class: 'ScmName', name: 'scripts' ]], \
 	                     userRemoteConfigs: [[ \
 	                         url: 'https://bitbucket.prd.nibr.novartis.net/scm/knim/knime-build-scripts.git'  \
 	                     ]]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,8 @@ pipeline {
 		PATH = "${M2_HOME}/bin:${PATH}"
     	KNIME_VERSION = "4.3"
     	UPDATE_SITE = "http://chbs-knime-app.tst.nibr.novartis.net/${KNIME_VERSION}/update/mirror"
-    	DEPLOY_UPDATE_SITE = "/apps/knime/web/${KNIME_VERSION}/update/nibr-test/"
+    	DEPLOY_MASTER_UPDATE_SITE = "/apps/knime/web/${KNIME_VERSION}/update/nibr"
+    	DEPLOY_BRANCH_UPDATE_SITE = "/apps/knime/web/${KNIME_VERSION}/update/knime-rdkit-review"
     	QUALIFIER_PREFIX = "vnibr"
     }
 
@@ -65,8 +66,8 @@ pipeline {
 					else {
 						// Deploy resulting build artifacts as review update (overriding an existing one)
 						sh '''
-							rm -rf "${DEPLOY_UPDATE_SITE}/${BRANCH_NAME}"
-							mv "${WORKSPACE}/org.rdkit.knime.update/target/repository" "${DEPLOY_UPDATE_SITE}/${BRANCH_NAME}"
+							rm -rf "${DEPLOY_BRANCH_UPDATE_SITE}/${BRANCH_NAME}"
+							mv "${WORKSPACE}/org.rdkit.knime.update/target/repository" "${DEPLOY_BRANCH_UPDATE_SITE}/${BRANCH_NAME}"
 						'''
 					}
 		        }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,10 +29,14 @@ pipeline {
 		    }    
         }
         stage('Installing Test Instance') {
-        
+        	steps {
+				        		
+        	}
         } 
         stage('Running Tests') {
-        
+        	steps {
+        		
+        	}
         } 
         stage('Deploying to Update Site') {
 			steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,36 @@ pipeline {
     	// Source update site used for building the KNIME Test Instance for regression testing
     	UPDATE_SITE = "http://chbs-knime-app.tst.nibr.novartis.net/${KNIME_VERSION}/update/mirror"
     	
+    	// Defines how tests are performed - this is passed in addition to the runTests method, which internally calls
+    	// the KNIME org.knime.testing.NGTestflowRunner application, which comes with the org.knime.features.testing.application feature.
+    	// To see an output of valid arguments like the following, specify an invalid argument.
+    	// 
+		// Valid arguments:
+		//     -include <regex>: only tests matching the regular expression <regex> will be run. The complete path of each testcase starting from the testflows' root directory is matched, e.g. '/Misc/Workflow'.
+		//     -root <dir_name>: optional, specifies the root dir where all testcases are located in. Multiple root arguments may be present.
+		//     -server <uri>: optional, a KNIME server  from which workflows should be downloaded first. Has to be used with -serverPath.
+		//                    Example: http://<user>:<password>@host[:port]/knime/rest
+		//     -serverPath <path>: optional, a path on the KNIME Server that specifies which workflows should be downloaded first.
+		//                    Example: /workflowGroup1/workflowGroup2
+		//     -xmlResult <file_name>: specifies a single XML  file where the test results are written to.
+		//     -xmlResultDir <directory_name>: specifies the directory  into which each test result is written to as an XML files. Either -xmlResult or -xmlResultDir must be provided.
+		//     -outputToSeparateFile: optional, specifies that system out and system err are written to a separate text file instead of being included in the XML result file (similar to Surefire)
+		//     -loadSaveLoad: optional, loads, saves, and loads the workflow before execution.
+		//     -deprecated: optional, reports deprecated nodes in workflows as failures.
+		//     -views: optional, opens all views during a workflow test.
+		//     -dialogs: optional, additional tests all node dialogs.
+		//     -logMessages: optional, checks for required or unexpected log messages.
+		//     -ignoreNodeMessages: optional, ignores any warning messages on nodes.
+		//     -untestedNodes <regex>: optional, checks for untested nodes, only node factories matching the regular expression are reported
+		//     -save <directory_name>: optional, specifies the directory  into which each testflow is saved after execution. If not specified the workflows are not saved.
+		//     -timeout <seconds>: optional, specifies the timeout for each individual workflow.
+		//     -stacktraceOnTimeout: optional, if specified output a full stack trace in case of timeouts.
+		//     -memLeaks <bytes>: optional, specifies the maximum allowed increaes in heap usage for each testflow. If not specified no test for memory leaks is performed.
+		//     -streaming: optional, enables additional streaming test for workflows configured accordingly. The test streaming job manager is set and used for each single node.
+		//     -preferences <file_name>: optional, specifies an exported preferences file that should be used to initialize preferences
+		//     -workflow.variable <variable-declaration>: optional, defines or overwrites workflow variable 'name' with value 'value' (possibly enclosed by quotes). The 'type' must be one of "String", "int" or "double".
+    	TEST_DEPTH_PARAMS = "-loadSaveLoad -views -dialogs -logMessages -streaming -stacktraceOnTimeout"
+    	
     	// Target update sites to use when everything was tested successfully to deploy the build artifacts
     	DEPLOY_MASTER_UPDATE_SITE = "/apps/knime/web/${KNIME_VERSION}/update/nibr"
     	DEPLOY_BRANCH_UPDATE_SITE = "/apps/knime/web/${KNIME_VERSION}/update/knime-rdkit-review"
@@ -86,7 +116,7 @@ pipeline {
 					}
 					export LC_NUMERIC=en_US.UTF-8
 					export RELEASE_REPOS="${UPDATE_SITE}"
-					runTests file://${WORKSPACE}/org.rdkit.knime.update/target/repository "noServerAccess" "${WORKSPACE}/org.rdkit.knime.testing/regression-tests/zips"
+					runTests file://${WORKSPACE}/org.rdkit.knime.update/target/repository "noServerAccess" "${WORKSPACE}/org.rdkit.knime.testing/regression-tests/zips" ${TEST_DEPTH_PARAMS}
 				'''
         	}
             post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,11 +94,7 @@ pipeline {
 					if (env.git_branch_lowercase == 'master' || env.GIT_BRANCH == 'master') {
 						// Add successfully tested RDKit artifacts to existing NIBR update site
 						sh '''
-							"${WORKSPACE}/scripts/mirrorSingleUpdateSite.sh" \
-								"${WORKSPACE}/tmp/knime\ test/knime" \
-								"${DEPLOY_MASTER_UPDATE_SITE}" true true \
-								"${WORKSPACE}/scripts/mirror.xml" \
-								"${WORKSPACE}/org.rdkit.knime.update/target/repository/"
+							"${WORKSPACE}/scripts/mirrorSingleUpdateSite.sh" "${WORKSPACE}/tmp/knime\ test/knime" "${DEPLOY_MASTER_UPDATE_SITE}" true true "${WORKSPACE}/scripts/mirror.xml" "${WORKSPACE}/org.rdkit.knime.update/target/repository/"
 						'''
 					} 
 					else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
 	        	// They will be checked out into a scripts directory, which resides within the root directory of the main checkout,
 	        	// which is sub-optimal, but no other solution was found so far
 				dir("scripts") {
-					checkout([$class: 'GitSCM', branches: [[name: '${GIT_BRANCH_SCRIPTS}']], doGenerateSubmoduleConfigurations: false, \
+					checkout([$class: 'GitSCM', branches: [[name: "${GIT_BRANCH_SCRIPTS}"]], doGenerateSubmoduleConfigurations: false, \
           			extensions: [], gitTool: 'default-git', submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'bitbucket-jenkins', \
           			url: "${GIT_REPO_SCRIPTS}"]]])
         		}
@@ -53,8 +53,8 @@ pipeline {
 				// Output environment
 				sh "env"
 				
-				// Cleanup old data
-				sh "rm -rf tmp results"
+				// Cleanup old data from last build
+				sh "rm -rf tmp results mirrorWorkspace"
 			}
 		}	 
         stage('Compile and Build') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,10 +19,6 @@ pipeline {
 		GIT_REPO_SCRIPTS = "https://bitbucket.prd.nibr.novartis.net/scm/knim/knime-build-scripts.git"
 		// TODO: Change to refs/heads/master
         GIT_BRANCH_SCRIPTS = "refs/heads/KNIME-1023_Setup_maven_as_build_tool"
-        
-        # Configuration for KNIME test instance
-        GIT_REPO_CONFIG = "https://bitbucket.prd.nibr.novartis.net/scm/knim/knime-client-config.git"
-    	GIT_BRANCH_CONFIG = "${KNIME_VERSION}"
     	
     	// Prefix for the version number of the artifacts to distinguish them from normal community builds 
     	// (vnibrYYYYMMDDHHSS always is considered a higher version than a community built version vYYYYMMDDHHSS)
@@ -30,9 +26,6 @@ pipeline {
     	
     	// Source update site used for building the KNIME Test Instance for regression testing
     	UPDATE_SITE = "http://chbs-knime-app.tst.nibr.novartis.net/${KNIME_VERSION}/update/mirror"
-    	
-    	// Define extra IUs to be installed for running test workflows
-    	EXTRA_IUs = "org.rdkit.knime.feature.feature.group," 
     	
     	// Target update sites to use when everything was tested successfully to deploy the build artifacts
     	DEPLOY_MASTER_UPDATE_SITE = "/apps/knime/web/${KNIME_VERSION}/update/nibr"
@@ -52,11 +45,6 @@ pipeline {
 					checkout([$class: 'GitSCM', branches: [[name: "${GIT_BRANCH_SCRIPTS}"]], doGenerateSubmoduleConfigurations: false, \
           			extensions: [], gitTool: 'default-git', submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'bitbucket-jenkins', \
           			url: "${GIT_REPO_SCRIPTS}"]]])
-        		}
-				dir("config") {
-					checkout([$class: 'GitSCM', branches: [[name: "${GIT_BRANCH_CONFIG}"]], doGenerateSubmoduleConfigurations: false, \
-          			extensions: [], gitTool: 'default-git', submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'bitbucket-jenkins', \
-          			url: "${GIT_REPO_CONFIG}"]]])
         		}
 	        }
 	    }   
@@ -88,9 +76,10 @@ pipeline {
 					ln -sf "${DIRECTOR_HOME}" "./scripts/knime-community/director"
 					# Apply NIBR KNIME configuration of DEV environment
 					source ./scripts/knime-community/community.inc
+					# This method gets called from the runTests() method after KNIME was installed, just before running tests
 					configureKnimeTestInstance() {
     					local knimeFolder=$1
-    					./scripts/applyConfig.sh "${knimeFolder}" ./config dev linux7 chbs IgnoreKnimeIni
+    					# Not used for RDKit tests
 					}
 					export LC_NUMERIC=en_US.UTF-8
 					export RELEASE_REPOS="${UPDATE_SITE}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
     	// Email addresses to be notified about failures, unstable tests or fixes
     	EMAIL_TO = 'manuel.schwarze@novartis.com'
     	
-		// A feature (branch or master) should always be built for one specific KNIME version only
+		// A feature (branch, master or master_nibr) should always be built for one specific KNIME version only
     	KNIME_VERSION = "4.3"
 
     	// Two pre-requisites that need to be installed by the NIBR Jenkins job knime4.x-all-setup-build-environment
@@ -73,7 +73,7 @@ pipeline {
     	DEPLOY_MASTER_UPDATE_SITE = "/apps/knime/web/${KNIME_VERSION}/update/nibr"
     	DEPLOY_BRANCH_UPDATE_SITE = "/apps/knime/web/${KNIME_VERSION}/update/knime-rdkit-review"
     	
-    	// Usually, this is set to "false", but in certain situations it can be necessary to deploy also branch builds the "master" update site - then set it to "true"
+    	// Usually, this is set to "false", but in certain situations it can be necessary to deploy also branch builds to the "master" update site - then set it to "true"
     	DEPLOY_BRANCH_BUILDS_TO_MASTER = "true"
     }
 
@@ -189,7 +189,7 @@ pipeline {
 				expression {
 					// Never run deployments on PROD, only on DEV or TEST
 					((env.ENVIRONMENT == 'dev' || env.ENVIRONMENT == 'test') &&
-					 (env.DEPLOY_BRANCH_BUILDS_TO_MASTER == 'true' || env.git_branch_lowercase == 'master' || env.GIT_BRANCH == 'master') &&
+					 (env.DEPLOY_BRANCH_BUILDS_TO_MASTER == 'true' || env.git_branch_lowercase == 'master_nibr' || env.GIT_BRANCH == 'master_nibr') &&
 					 (currentBuild.result == null || currentBuild.result == 'SUCCESS'))
               	}
             }        
@@ -208,7 +208,7 @@ pipeline {
 				expression {
 					// Never run deployments on PROD, only on DEV or TEST
 					((env.ENVIRONMENT == 'dev' || env.ENVIRONMENT == 'test') &&
-					 (env.git_branch_lowercase != 'master' && env.GIT_BRANCH != 'master')) 
+					 (env.git_branch_lowercase != 'master_nibr' && env.GIT_BRANCH != 'master_nibr')) 
               	}
             }
 			steps {
@@ -223,12 +223,12 @@ pipeline {
 		        }
 		    }
         }
-        stage('Package and Rollout (only master)') {
+        stage('Package and Rollout (only master_nibr)') {
          	when {
 				expression {
 					// Never run deployments on PROD, only on DEV or TEST
 					((env.ENVIRONMENT == 'dev' || env.ENVIRONMENT == 'test') &&
-					 (env.DEPLOY_BRANCH_BUILDS_TO_MASTER == 'true' || env.git_branch_lowercase == 'master' || env.GIT_BRANCH == 'master') &&
+					 (env.DEPLOY_BRANCH_BUILDS_TO_MASTER == 'true' || env.git_branch_lowercase == 'master_nibr' || env.GIT_BRANCH == 'master_nibr') &&
 					 (currentBuild.result == null || currentBuild.result == 'SUCCESS'))
               	}
             }        


### PR DESCRIPTION
The provided Jenkinsfile has been officially released by NIBR as open source for multiple purposes:

- It demonstrates how to setup a multi-branch building and testing pipeline for KNIME plugins
- It works in the NIBR Jenkins environment, in which most features are developed, to allow builds already in the state of a pull requests and branch to support best software development practices (this was not possible before), and 
- It may serve as blueprint for also enabling similar capabilities later in the KNIME Community Jenkins server (with a different file)

I verified with KNIME DevOps (Gabriel Einsdorf) that the file will have no negative side effects on the KNIME Community Jenkins server.