### PR TITLE
A couple of minor improvements

### DIFF
--- a/org.rdkit.knime.feature/feature.xml
+++ b/org.rdkit.knime.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.feature"
       label="RDKit Nodes Feature"
-      version="4.3.0.qualifier"
+      version="4.3.1.qualifier"
       provider-name="NIBR"
       plugin="org.rdkit.knime.nodes">
 

--- a/org.rdkit.knime.nodes/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.nodes/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Nodes
 Bundle-SymbolicName: org.rdkit.knime.nodes;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.nodes
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Vendor: NIBR
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui;bundle-version="[3.109.0,4.0.0)",

--- a/org.rdkit.knime.nodes/src/org/rdkit/knime/nodes/highlighting/RDKitHighlightingNodeModel.java
+++ b/org.rdkit.knime.nodes/src/org/rdkit/knime/nodes/highlighting/RDKitHighlightingNodeModel.java
@@ -60,6 +60,7 @@ import org.RDKit.ColourPalette;
 import org.RDKit.DrawColour;
 import org.RDKit.Int_Vect;
 import org.RDKit.MolDraw2DSVG;
+import org.RDKit.MolDrawOptions;
 import org.RDKit.ROMol;
 import org.knime.base.data.xml.SvgCell;
 import org.knime.base.data.xml.SvgCellFactory;
@@ -417,6 +418,8 @@ public class RDKitHighlightingNodeModel extends AbstractRDKitCalculatorNodeModel
 					}
 
 					final MolDraw2DSVG molDrawing = markForCleanup(new MolDraw2DSVG(300, 300), lUniqueWaveId);
+					MolDrawOptions opts = molDrawing.drawOptions();
+					opts.setAddStereoAnnotation(true);
 					molDrawing.drawMolecule(mol, "", ivAtoms, ivBonds, mapRdkitAtomColors, mapRdkitBondColors);
 					molDrawing.finishDrawing();
 

--- a/org.rdkit.knime.nodes/src/org/rdkit/knime/nodes/preferences/RDKitNodesPreferencePage.java
+++ b/org.rdkit.knime.nodes/src/org/rdkit/knime/nodes/preferences/RDKitNodesPreferencePage.java
@@ -54,6 +54,7 @@ import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
+import org.RDKit.RDKFuncs;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtension;
 import org.eclipse.core.runtime.IExtensionPoint;
@@ -137,7 +138,7 @@ implements IWorkbenchPreferencePage {
 
 		// We use the pref store of the UI plugin
 		setPreferenceStore(RDKitNodePlugin.getDefault().getPreferenceStore());
-		setDescription("This section contains sub sections to control preferences for RDKit Nodes.");
+		setDescription("This section contains sub sections to control preferences for the RDKit Nodes.\nThe nodes are using version "+RDKFuncs.getRdkitVersion()+" of the RDKit backend.");
 	}
 
 	/** {@inheritDoc} */

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitMolValueRenderer.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitMolValueRenderer.java
@@ -275,6 +275,7 @@ implements SvgProvider {
 				MolDrawOptions opts = molDrawing.drawOptions();
 				// we've already prepared the molecule appropriately, so don't try again:
 				opts.setPrepareMolsBeforeDrawing(false);
+				opts.setAddStereoAnnotation(true);
 				molDrawing.drawMolecule((ROMol)mol);
 				molDrawing.finishDrawing();
 


### PR DESCRIPTION
Changes here:
- show chirality and enhanced stereo labels in the renderers
![image](https://user-images.githubusercontent.com/540511/133631178-6b9eebc0-8ab9-46ba-b49d-29ba777fbeae.png)

- show the version number of the RDKit backend in the preferences page:
![image](https://user-images.githubusercontent.com/540511/133631231-af004df2-bc7f-4810-af9c-39d0085da5b9.png)

- bump nodes version


This can stand on it's own, but I would really prefer to have #95 merged first, then this one.