### PR TITLE
Update to OPSIN 2.6.0 incl. log4j 2.17 - Version bump to 4.5.0 (#100)

### DIFF
--- a/org.rdkit.knime.bin.linux.x86_64/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.bin.linux.x86_64/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDKit binaries for 64bit Linux
 Bundle-SymbolicName: org.rdkit.knime.bin.linux.x86_64;singleton:=true
-Bundle-Version: 4.4.1.qualifier
-Fragment-Host: org.rdkit.knime.types;bundle-version="4.4.1"
+Bundle-Version: 4.5.0.qualifier
+Fragment-Host: org.rdkit.knime.types;bundle-version="4.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Eclipse-PlatformFilter: (&(osgi.os=linux)(osgi.arch=x86_64))
 Bundle-Vendor: NIBR

--- a/org.rdkit.knime.bin.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.bin.macosx.x86_64/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDKit binaries for 64bit MacOSX
 Bundle-SymbolicName: org.rdkit.knime.bin.macosx.x86_64;singleton:=true
-Bundle-Version: 4.4.1.qualifier
-Fragment-Host: org.rdkit.knime.types;bundle-version="4.4.1"
+Bundle-Version: 4.5.0.qualifier
+Fragment-Host: org.rdkit.knime.types;bundle-version="4.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Eclipse-PlatformFilter: (&(osgi.os=macosx)(osgi.arch=x86_64))
 Bundle-Vendor: NIBR

--- a/org.rdkit.knime.bin.win32.x86_64/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.bin.win32.x86_64/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDKit binaries for 64bit Windows
 Bundle-SymbolicName: org.rdkit.knime.bin.win32.x86_64;singleton:=true
-Bundle-Version: 4.4.1.qualifier
-Fragment-Host: org.rdkit.knime.types;bundle-version="4.4.1"
+Bundle-Version: 4.5.0.qualifier
+Fragment-Host: org.rdkit.knime.types;bundle-version="4.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Eclipse-PlatformFilter: (&(osgi.os=win32)(osgi.arch=x86_64))
 Bundle-Vendor: NIBR

--- a/org.rdkit.knime.binaries.feature/feature.xml
+++ b/org.rdkit.knime.binaries.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.binaries.feature"
       label="RDKit Binaries and Chemistry Type Definitions Feature"
-      version="4.4.1.qualifier"
+      version="4.5.0.qualifier"
       provider-name="NIBR">
 
    <description>

--- a/org.rdkit.knime.feature/feature.xml
+++ b/org.rdkit.knime.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.feature"
       label="RDKit Nodes Feature"
-      version="4.4.1.qualifier"
+      version="4.5.0.qualifier"
       provider-name="NIBR"
       plugin="org.rdkit.knime.nodes">
 

--- a/org.rdkit.knime.nodes/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.nodes/META-INF/MANIFEST.MF
@@ -3,14 +3,14 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Nodes
 Bundle-SymbolicName: org.rdkit.knime.nodes;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.nodes
-Bundle-Version: 4.4.1.qualifier
+Bundle-Version: 4.5.0.qualifier
 Bundle-Vendor: NIBR
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui;bundle-version="[3.109.0,4.0.0)",
  org.knime.base;bundle-version="[4.2.0,5.0.0)",
  org.knime.chem.types;bundle-version="[4.2.0,5.0.0)",
  org.knime.workbench.repository;bundle-version="[4.2.0,5.0.0)",
- org.rdkit.knime.types;bundle-version="[4.4.1,5.0.0)",
+ org.rdkit.knime.types;bundle-version="[4.5.0,5.0.0)",
  org.knime.ext.svg;bundle-version="[4.2.0,5.0.0)"
 Export-Package: org.rdkit.knime.nodes,
  org.rdkit.knime.nodes.addconformers,
@@ -61,5 +61,5 @@ Export-Package: org.rdkit.knime.nodes,
 Bundle-Activator: org.rdkit.knime.nodes.RDKitNodePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,
- lib/opsin-core-3.0-excludingInChI-jar-with-dependencies.jar
+ lib/opsin-core-2.6.0-jar-with-dependencies.jar
 Import-Package: org.w3c.dom.events;version="3.0.0"

--- a/org.rdkit.knime.nodes/build.properties
+++ b/org.rdkit.knime.nodes/build.properties
@@ -4,7 +4,7 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               lib/opsin-core-3.0-excludingInChI-jar-with-dependencies.jar,\
+               lib/opsin-core-2.6.0-jar-with-dependencies.jar,\
                icons/
-jars.extra.classpath = lib/opsin-core-3.0-excludingInChI-jar-with-dependencies.jar,\
+jars.extra.classpath = lib/opsin-core-2.6.0-jar-with-dependencies.jar,\
 					   platform:/plugin/org.rdkit.knime.types/lib/org.RDKit.jar

--- a/org.rdkit.knime.testing.feature/feature.xml
+++ b/org.rdkit.knime.testing.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.testing.feature"
       label="RDKit Nodes Tests Feature"
-      version="4.4.1.qualifier"
+      version="4.5.0.qualifier"
       provider-name="NIBR">
 
    <description>

--- a/org.rdkit.knime.testing/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.testing/META-INF/MANIFEST.MF
@@ -3,10 +3,10 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Nodes Tests
 Bundle-SymbolicName: org.rdkit.knime.testing;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.testing
-Bundle-Version: 4.4.1.qualifier
+Bundle-Version: 4.5.0.qualifier
 Bundle-Vendor: NIBR
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Fragment-Host: org.rdkit.knime.nodes;bundle-version="4.4.1"
+Fragment-Host: org.rdkit.knime.nodes;bundle-version="4.5.0"
 Require-Bundle: org.knime.testing;bundle-version="[3.7.0,5.0.0)",
  org.knime.chem.base;bundle-version="[3.6.0,5.0.0)"
 Bundle-ClassPath: rdkit-testing.jar

--- a/org.rdkit.knime.types/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.types/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: rdkit-chem.jar,
  lib/org.RDKit.jar,
  lib/org.RDKitDoc.jar
-Bundle-Version: 4.4.1.qualifier
+Bundle-Version: 4.5.0.qualifier
 Bundle-Name: RDKit Chemistry Type Definitions
 Bundle-Activator: org.rdkit.knime.RDKitTypesPluginActivator
 Bundle-ManifestVersion: 2

--- a/org.rdkit.knime.wizards.feature/feature.xml
+++ b/org.rdkit.knime.wizards.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.wizards.feature"
       label="RDKit Nodes Creation Wizards Feature"
-      version="4.4.1.qualifier"
+      version="4.5.0.qualifier"
       provider-name="NIBR"
       plugin="org.rdkit.knime.wizards">
 

--- a/org.rdkit.knime.wizards.samples/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.wizards.samples/META-INF/MANIFEST.MF
@@ -3,13 +3,13 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Nodes Creation Wizards Samples
 Bundle-SymbolicName: org.rdkit.knime.wizards.samples;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.wizards.samples
-Bundle-Version: 4.4.1.qualifier
+Bundle-Version: 4.5.0.qualifier
 Bundle-Activator: org.rdkit.knime.wizards.samples.Activator
 Bundle-Vendor: NIBR
 Require-Bundle: org.knime.base;bundle-version="[4.3.0,5.0.0)";resolution:=optional,
  org.knime.chem.types;bundle-version="[4.3.0,5.0.0)";resolution:=optional,
- org.rdkit.knime.nodes;bundle-version="[4.4.1,5.0.0)";resolution:=optional,
- org.rdkit.knime.types;bundle-version="[4.4.1,5.0.0)";resolution:=optional,
+ org.rdkit.knime.nodes;bundle-version="[4.5.0,5.0.0)";resolution:=optional,
+ org.rdkit.knime.types;bundle-version="[4.5.0,5.0.0)";resolution:=optional,
  org.eclipse.ui;bundle-version="[3.116.0,4.0.0)";resolution:=optional,
  org.eclipse.core.runtime;bundle-version="[3.17.0,4.0.0)";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.rdkit.knime.wizards/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.wizards/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Nodes Creation Wizards
 Bundle-SymbolicName: org.rdkit.knime.wizards;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.wizards
-Bundle-Version: 4.4.1.qualifier
+Bundle-Version: 4.5.0.qualifier
 Bundle-Activator: org.rdkit.knime.wizards.RDKitNodesWizardsPlugin
 Bundle-Vendor: NIBR
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.7.0,4.0.0)",

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<revision>4.4.1</revision>
+		<revision>4.5.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<knime.version>4.3</knime.version>
 		<tycho.version>1.5.1</tycho.version>


### PR DESCRIPTION
OPSIN 2.6.0 library was released with latest log4j 2.17 update and finalization of many other features (#100)
Version of all RDKit extensions was updated to 4.5.0
Reference: [OPSIN issue #174](https://github.com/dan2097/opsin/issues/174)