### PR TITLE
Add RDKit type support for KNIME's new Python (Labs) integration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin
 /org.rdkit.knime.types/python/*.pyc
+**/__pycache__/
 /.metadata/
 .polyglot.feature.xml.takari_issue_192
 .polyglot..META-INF_MANIFEST.MF

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extensions>
     <extension>
-        <groupId>org.eclipse.tycho.extras</groupId>
-        <artifactId>tycho-pomless</artifactId>
-        <version>1.5.1</version>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-build</artifactId>
+        <version>2.7.3</version>
     </extension>
 </extensions>

--- a/org.rdkit.knime.bin.linux.x86_64/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.bin.linux.x86_64/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDKit binaries for 64bit Linux
 Bundle-SymbolicName: org.rdkit.knime.bin.linux.x86_64;singleton:=true
-Bundle-Version: 4.5.0.qualifier
-Fragment-Host: org.rdkit.knime.types;bundle-version="4.5.0"
+Bundle-Version: 4.7.0.qualifier
+Fragment-Host: org.rdkit.knime.types;bundle-version="4.7.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Eclipse-PlatformFilter: (&(osgi.os=linux)(osgi.arch=x86_64))
 Bundle-Vendor: NIBR

--- a/org.rdkit.knime.bin.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.bin.macosx.x86_64/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDKit binaries for 64bit MacOSX
 Bundle-SymbolicName: org.rdkit.knime.bin.macosx.x86_64;singleton:=true
-Bundle-Version: 4.5.0.qualifier
-Fragment-Host: org.rdkit.knime.types;bundle-version="4.5.0"
+Bundle-Version: 4.7.0.qualifier
+Fragment-Host: org.rdkit.knime.types;bundle-version="4.7.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Eclipse-PlatformFilter: (&(osgi.os=macosx)(osgi.arch=x86_64))
 Bundle-Vendor: NIBR

--- a/org.rdkit.knime.bin.win32.x86_64/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.bin.win32.x86_64/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDKit binaries for 64bit Windows
 Bundle-SymbolicName: org.rdkit.knime.bin.win32.x86_64;singleton:=true
-Bundle-Version: 4.5.0.qualifier
-Fragment-Host: org.rdkit.knime.types;bundle-version="4.5.0"
+Bundle-Version: 4.7.0.qualifier
+Fragment-Host: org.rdkit.knime.types;bundle-version="4.7.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Eclipse-PlatformFilter: (&(osgi.os=win32)(osgi.arch=x86_64))
 Bundle-Vendor: NIBR

--- a/org.rdkit.knime.binaries.feature/feature.xml
+++ b/org.rdkit.knime.binaries.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.binaries.feature"
       label="RDKit Binaries and Chemistry Type Definitions Feature"
-      version="4.5.0.qualifier"
+      version="4.7.0.qualifier"
       provider-name="NIBR">
 
    <description>

--- a/org.rdkit.knime.feature/feature.xml
+++ b/org.rdkit.knime.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.feature"
       label="RDKit Nodes Feature"
-      version="4.5.0.qualifier"
+      version="4.7.0.qualifier"
       provider-name="NIBR"
       plugin="org.rdkit.knime.nodes">
 

--- a/org.rdkit.knime.nodes/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.nodes/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Nodes
 Bundle-SymbolicName: org.rdkit.knime.nodes;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.nodes
-Bundle-Version: 4.5.0.qualifier
+Bundle-Version: 4.6.0.qualifier
 Bundle-Vendor: NIBR
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui;bundle-version="[3.109.0,4.0.0)",
@@ -62,4 +62,3 @@ Bundle-Activator: org.rdkit.knime.nodes.RDKitNodePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,
  lib/opsin-core-3.0-SNAPSHOT-2022-07-04-jar-with-dependencies.jar
-Import-Package: org.w3c.dom.events;version="3.0.0"

--- a/org.rdkit.knime.nodes/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.nodes/META-INF/MANIFEST.MF
@@ -3,15 +3,15 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Nodes
 Bundle-SymbolicName: org.rdkit.knime.nodes;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.nodes
-Bundle-Version: 4.6.0.qualifier
+Bundle-Version: 4.7.0.qualifier
 Bundle-Vendor: NIBR
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui;bundle-version="[3.109.0,4.0.0)",
- org.knime.base;bundle-version="[4.2.0,5.0.0)",
- org.knime.chem.types;bundle-version="[4.2.0,5.0.0)",
- org.knime.workbench.repository;bundle-version="[4.2.0,5.0.0)",
- org.rdkit.knime.types;bundle-version="[4.5.0,5.0.0)",
- org.knime.ext.svg;bundle-version="[4.2.0,5.0.0)"
+ org.knime.base;bundle-version="[4.7.0,5.0.0)",
+ org.knime.chem.types;bundle-version="[4.7.0,5.0.0)",
+ org.knime.workbench.repository;bundle-version="[4.7.0,5.0.0)",
+ org.rdkit.knime.types;bundle-version="[4.7.0,5.0.0)",
+ org.knime.ext.svg;bundle-version="[4.7.0,5.0.0)"
 Export-Package: org.rdkit.knime.nodes,
  org.rdkit.knime.nodes.addconformers,
  org.rdkit.knime.nodes.addcoordinates;uses:="org.knime.core.node,org.knime.core.node.defaultnodesettings",

--- a/org.rdkit.knime.testing.feature/feature.xml
+++ b/org.rdkit.knime.testing.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.testing.feature"
       label="RDKit Nodes Tests Feature"
-      version="4.5.0.qualifier"
+      version="4.7.0.qualifier"
       provider-name="NIBR">
 
    <description>

--- a/org.rdkit.knime.testing/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.testing/META-INF/MANIFEST.MF
@@ -3,10 +3,10 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Nodes Tests
 Bundle-SymbolicName: org.rdkit.knime.testing;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.testing
-Bundle-Version: 4.5.0.qualifier
+Bundle-Version: 4.7.0.qualifier
 Bundle-Vendor: NIBR
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Fragment-Host: org.rdkit.knime.nodes;bundle-version="4.5.0"
-Require-Bundle: org.knime.testing;bundle-version="[3.7.0,5.0.0)",
- org.knime.chem.base;bundle-version="[3.6.0,5.0.0)"
+Fragment-Host: org.rdkit.knime.nodes;bundle-version="4.7.0"
+Require-Bundle: org.knime.testing;bundle-version="[4.7.0,5.0.0)",
+ org.knime.chem.base;bundle-version="[4.7.0,5.0.0)"
 Bundle-ClassPath: rdkit-testing.jar

--- a/org.rdkit.knime.types/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.types/META-INF/MANIFEST.MF
@@ -10,8 +10,8 @@ Require-Bundle: org.knime.base;bundle-version="[3.6.2,5.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.13.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.109.0,4.0.0)",
  org.knime.ext.svg;bundle-version="[3.6.2,5.0.0)",
- org.apache.batik.dom.svg;bundle-version="[1.13.0,1.14.0)",
- org.apache.batik.util;bundle-version="[1.13.0,1.14.0)",
+ org.apache.batik.dom.svg;bundle-version="[1.13.0,2.0.0)",
+ org.apache.batik.util;bundle-version="[1.13.0,2.0.0)",
  org.knime.chem.types;bundle-version="[3.6.0,5.0.0)",
  org.knime.workbench.repository;bundle-version="[3.6.0,5.0.0)",
  org.knime.workbench.ui;bundle-version="[3.6.0,5.0.0)",
@@ -29,4 +29,3 @@ Bundle-SymbolicName: org.rdkit.knime.types;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.types
 Eclipse-RegisterBuddy: org.knime.base
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.w3c.dom.events;version="3.0.0"

--- a/org.rdkit.knime.types/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.types/META-INF/MANIFEST.MF
@@ -15,7 +15,9 @@ Require-Bundle: org.knime.base;bundle-version="[4.7.0,5.0.0)",
  org.knime.chem.types;bundle-version="[4.7.0,5.0.0)",
  org.knime.workbench.repository;bundle-version="[4.7.0,5.0.0)",
  org.knime.workbench.ui;bundle-version="[4.7.0,5.0.0)",
- org.knime.python.typeextensions;bundle-version="[3.5.0,5.0.0)";resolution:=optional
+ org.knime.python.typeextensions;bundle-version="[4.7.0,5.0.0)";resolution:=optional,
+ org.knime.core.table;bundle-version="[4.7.0,5.0.0)",
+ org.knime.python3.types;bundle-version="[4.7.0,5.0.0)";resolution:=optional
 Bundle-Vendor: NIBR
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: rdkit-chem.jar,

--- a/org.rdkit.knime.types/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.types/META-INF/MANIFEST.MF
@@ -5,23 +5,23 @@ Export-Package: org.RDKit,
  org.rdkit.knime.types,
  org.rdkit.knime.types.preferences,
  org.rdkit.knime.util
-Require-Bundle: org.knime.base;bundle-version="[3.6.2,5.0.0)",
+Require-Bundle: org.knime.base;bundle-version="[4.7.0,5.0.0)",
  org.eclipse.osgi;bundle-version="[3.12.100,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.13.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.109.0,4.0.0)",
- org.knime.ext.svg;bundle-version="[3.6.2,5.0.0)",
+ org.knime.ext.svg;bundle-version="[4.7.0,5.0.0)",
  org.apache.batik.dom.svg;bundle-version="[1.13.0,2.0.0)",
  org.apache.batik.util;bundle-version="[1.13.0,2.0.0)",
- org.knime.chem.types;bundle-version="[3.6.0,5.0.0)",
- org.knime.workbench.repository;bundle-version="[3.6.0,5.0.0)",
- org.knime.workbench.ui;bundle-version="[3.6.0,5.0.0)",
+ org.knime.chem.types;bundle-version="[4.7.0,5.0.0)",
+ org.knime.workbench.repository;bundle-version="[4.7.0,5.0.0)",
+ org.knime.workbench.ui;bundle-version="[4.7.0,5.0.0)",
  org.knime.python.typeextensions;bundle-version="[3.5.0,5.0.0)";resolution:=optional
 Bundle-Vendor: NIBR
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: rdkit-chem.jar,
  lib/org.RDKit.jar,
  lib/org.RDKitDoc.jar
-Bundle-Version: 4.5.0.qualifier
+Bundle-Version: 4.7.0.qualifier
 Bundle-Name: RDKit Chemistry Type Definitions
 Bundle-Activator: org.rdkit.knime.RDKitTypesPluginActivator
 Bundle-ManifestVersion: 2

--- a/org.rdkit.knime.types/plugin.xml
+++ b/org.rdkit.knime.types/plugin.xml
@@ -14,6 +14,16 @@
    	   	  		cellClass="org.rdkit.knime.types.RDKitAdapterCell" 
    	   	  		serializerClass="org.rdkit.knime.types.RDKitAdapterCell$RDKitAdapterCellSerializer">
           </serializer>
+          <ValueFactory
+                deprecated="false"
+                cellClass="org.rdkit.knime.types.RDKitMolCell2"
+                valueFactoryClass="org.rdkit.knime.types.RDKitMolCellValueFactory">
+          </ValueFactory>
+          <ValueFactory
+                deprecated="false"
+                cellClass="org.rdkit.knime.types.RDKitAdapterCell"
+                valueFactoryClass="org.rdkit.knime.types.RDKitAdapterCellValueFactory">
+          </ValueFactory>
       </DataType>
    </extension>
    
@@ -23,6 +33,11 @@
                 cellClass="org.rdkit.knime.types.RDKitReactionCell"
                 serializerClass="org.rdkit.knime.types.RDKitReactionCell$RDKitReactionSerializer">
           </serializer>
+          <ValueFactory
+                deprecated="false"
+                cellClass="org.rdkit.knime.types.RDKitReactionCell"
+                valueFactoryClass="org.rdkit.knime.types.RDKitReactionCellValueFactory">
+          </ValueFactory>
    	   </DataType>
    </extension>
    
@@ -136,5 +151,48 @@
             python-serializer="python/RDKitLongSparseIntVectSerializer.py"
             java-deserializer-factory="org.rdkit.knime.types.RDKitCountBasedFingerprintDeserializer$Factory">
       	</type>   
+   </extension>
+   <extension
+         point="org.knime.python3.types.PythonValueFactory">
+      <Module
+            modulePath="python3" moduleName="knime.types.ext.rdkit">
+         <PythonValueFactory
+               PythonClassName="RDKitMolValueFactory"
+               ValueFactory="org.rdkit.knime.types.RDKitMolCellValueFactory">
+         </PythonValueFactory>
+         <PythonValueFactory
+               PythonClassName="RDKitMolAdapterValueFactory"
+               ValueFactory="org.rdkit.knime.types.RDKitAdapterCellValueFactory">
+         </PythonValueFactory>
+         <PythonValueFactory
+               PythonClassName="RDKitReactionValueFactory"
+               ValueFactory="org.rdkit.knime.types.RDKitReactionCellValueFactory">
+         </PythonValueFactory>
+         <PythonValueFactory
+               PythonClassName="RDKitFingerprintValueFactory"
+               ValueFactory="org.knime.core.data.v2.value.DenseBitVectorValueFactory"
+               isDefaultPythonRepresentation="false">
+         </PythonValueFactory>
+         <PythonValueFactory
+               PythonClassName="RDKitCountFingerprintValueFactoryUInt"
+               ValueFactory="org.knime.core.data.v2.value.DenseByteVectorValueFactory"
+               isDefaultPythonRepresentation="false">
+         </PythonValueFactory>
+         <PythonValueFactory
+               PythonClassName="RDKitCountFingerprintValueFactoryInt"
+               ValueFactory="org.knime.core.data.v2.value.DenseByteVectorValueFactory"
+               isDefaultPythonRepresentation="false">
+         </PythonValueFactory>
+         <PythonValueFactory
+               PythonClassName="RDKitCountFingerprintValueFactoryULong"
+               ValueFactory="org.knime.core.data.v2.value.DenseByteVectorValueFactory"
+               isDefaultPythonRepresentation="false">
+         </PythonValueFactory>
+         <PythonValueFactory
+               PythonClassName="RDKitCountFingerprintValueFactoryLong"
+               ValueFactory="org.knime.core.data.v2.value.DenseByteVectorValueFactory"
+               isDefaultPythonRepresentation="false">
+         </PythonValueFactory>
+      </Module>
    </extension>   
    </plugin>

--- a/org.rdkit.knime.types/python/RDKitIntSparseIntVectSerializer.py
+++ b/org.rdkit.knime.types/python/RDKitIntSparseIntVectSerializer.py
@@ -1,2 +1,11 @@
 def serialize(object_value):
-	return str({"length":object_value.GetLength(),"bits":object_value.GetNonzeroElements()})
+    s = str(
+        {"length": object_value.GetLength(), "bits": object_value.GetNonzeroElements()}
+    )
+
+    import sys
+
+    if sys.version_info.major > 2:
+        s = s.encode()
+
+    return s

--- a/org.rdkit.knime.types/python/RDKitLongSparseIntVectSerializer.py
+++ b/org.rdkit.knime.types/python/RDKitLongSparseIntVectSerializer.py
@@ -1,2 +1,11 @@
 def serialize(object_value):
-	return str({"length":object_value.GetLength(),"bits":object_value.GetNonzeroElements()})
+    s = str(
+        {"length": object_value.GetLength(), "bits": object_value.GetNonzeroElements()}
+    )
+
+    import sys
+
+    if sys.version_info.major > 2:
+        s = s.encode()
+
+    return s

--- a/org.rdkit.knime.types/python/RDKitUIntSparseIntVectSerializer.py
+++ b/org.rdkit.knime.types/python/RDKitUIntSparseIntVectSerializer.py
@@ -1,2 +1,11 @@
 def serialize(object_value):
-	return str({"length":object_value.GetLength(),"bits":object_value.GetNonzeroElements()})
+    s = str(
+        {"length": object_value.GetLength(), "bits": object_value.GetNonzeroElements()}
+    )
+
+    import sys
+
+    if sys.version_info.major > 2:
+        s = s.encode()
+
+    return s

--- a/org.rdkit.knime.types/python3/knime/types/ext/rdkit.py
+++ b/org.rdkit.knime.types/python3/knime/types/ext/rdkit.py
@@ -68,6 +68,7 @@ try:
         ULongSparseIntVect,
         LongSparseIntVect,
     )
+    from rdkit.DataStructs import CreateFromBinaryText, BitVectToBinaryText
 
 except ImportError as e:
     LOGGER.info(
@@ -153,19 +154,16 @@ class RDKitFingerprintValueFactory(kt.PythonValueFactory):
     def decode(self, storage):
         if storage is None:
             return None
-        import rdkit
 
-        length = int.from_bytes(storage[:8], byteorder="little")
-        fp = rdkit.DataStructs.CreateFromBinaryText(storage[8:])
+        fp = CreateFromBinaryText(storage[8:])
         return fp
 
     def encode(self, value):
         if value is None:
             return None
-        import rdkit
 
         length_bytes = len(value).to_bytes(length=8, byteorder="little")
-        return length_bytes + rdkit.DataStructs.BitVectToBinaryText(value)
+        return length_bytes + BitVectToBinaryText(value)
 
 
 class AbstractRDKitCountFingerprintValueFactory(kt.PythonValueFactory):
@@ -190,7 +188,7 @@ class AbstractRDKitCountFingerprintValueFactory(kt.PythonValueFactory):
 
         ba = bytearray(value.GetLength())
         for idx, v in value.GetNonzeroElements().items():
-            ba[idx] = v
+            ba[idx] = v % 256
         return ba
 
 

--- a/org.rdkit.knime.types/python3/knime/types/ext/rdkit.py
+++ b/org.rdkit.knime.types/python3/knime/types/ext/rdkit.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------
+#  Copyright by KNIME AG, Zurich, Switzerland
+#  Website: http://www.knime.com; Email: contact@knime.com
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License, Version 3, as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, see <http://www.gnu.org/licenses>.
+#
+#  Additional permission under GNU GPL version 3 section 7:
+#
+#  KNIME interoperates with ECLIPSE solely via ECLIPSE's plug-in APIs.
+#  Hence, KNIME and ECLIPSE are both independent programs and are not
+#  derived from each other. Should, however, the interpretation of the
+#  GNU GPL Version 3 ("License") under any applicable laws result in
+#  KNIME and ECLIPSE being a combined program, KNIME AG herewith grants
+#  you the additional permission to use and propagate KNIME together with
+#  ECLIPSE with only the license terms in place for ECLIPSE applying to
+#  ECLIPSE and the GNU GPL Version 3 applying for KNIME, provided the
+#  license terms of ECLIPSE themselves allow for the respective use and
+#  propagation of ECLIPSE together with KNIME.
+#
+#  Additional permission relating to nodes for KNIME that extend the Node
+#  Extension (and in particular that are based on subclasses of NodeModel,
+#  NodeDialog, and NodeView) and that only interoperate with KNIME through
+#  standard APIs ("Nodes"):
+#  Nodes are deemed to be separate and independent programs and to not be
+#  covered works.  Notwithstanding anything to the contrary in the
+#  License, the License does not apply to Nodes, you are not required to
+#  license Nodes under the License, and you are granted a license to
+#  prepare and propagate Nodes, in each case even if such Nodes are
+#  propagated with or for interoperation with KNIME.  The owner of a Node
+#  may freely choose the license terms applicable to such Node, including
+#  when such Node is propagated with or for interoperation with KNIME.
+# ------------------------------------------------------------------------
+
+"""
+Defines a PythonValueFactory that determines how RDKit cells
+are read and written from/to the underlying table in Python.
+
+@author Carsten Haubold, KNIME GmbH, Konstanz, Germany
+"""
+import logging
+import knime_types as kt
+
+LOGGER = logging.getLogger(__name__)
+
+try:
+    # We cannot import rdkit at the top of the file because it would then be required
+    # everywhere, even if we do not use the RDKit columns or don't even
+    # have an RDKit column in the table but the type is registered.
+    # All Python environments used in KNIME would then have to provide rdkit,
+    # which we don't want.
+    from rdkit import Chem
+    from rdkit.Chem.rdChemReactions import ChemicalReaction
+    from rdkit.DataStructs.cDataStructs import (
+        ExplicitBitVect,
+        UIntSparseIntVect,
+        IntSparseIntVect,
+        ULongSparseIntVect,
+        LongSparseIntVect,
+    )
+
+except ImportError as e:
+    LOGGER.info(
+        "RDKit type support not available because 'rdkit' could not be imported", e
+    )
+
+    # we define a dummy type Chem.Mol to be used instead.
+    # Any attempt to work with this data will fail.
+    class Chem:
+        class Mol:
+            pass
+
+    class ChemicalReaction:
+        pass
+
+    class ExplicitBitVect:
+        pass
+
+    class UIntSparseIntVect:
+        pass
+
+    class IntSparseIntVect:
+        pass
+
+    class LongSparseIntVect:
+        pass
+
+    class ULongSparseIntVect:
+        pass
+
+
+class RDKitMolAdapterValueFactory(kt.PythonValueFactory):
+    def __init__(self):
+        kt.PythonValueFactory.__init__(self, Chem.Mol)
+
+    def decode(self, storage):
+        if storage is None:
+            return None
+
+        value = Chem.Mol(storage["0"])
+        return value
+
+    def encode(self, value):
+        if value is None:
+            return None
+        return {"0": value.ToBinary(), "1": None}
+
+
+class RDKitMolValueFactory(kt.PythonValueFactory):
+    def __init__(self):
+        kt.PythonValueFactory.__init__(self, Chem.Mol)
+
+    def decode(self, storage):
+        if storage is None:
+            return None
+        return Chem.Mol(storage)
+
+    def encode(self, value):
+        if value is None:
+            return None
+        return value.ToBinary()
+
+
+class RDKitReactionValueFactory(kt.PythonValueFactory):
+    def __init__(self):
+        kt.PythonValueFactory.__init__(self, ChemicalReaction)
+
+    def decode(self, storage):
+        if storage is None:
+            return None
+        return ChemicalReaction(storage)
+
+    def encode(self, value):
+        if value is None:
+            return None
+        return value.ToBinary()
+
+
+class RDKitFingerprintValueFactory(kt.PythonValueFactory):
+    def __init__(self):
+        kt.PythonValueFactory.__init__(self, ExplicitBitVect)
+
+    def decode(self, storage):
+        if storage is None:
+            return None
+        import rdkit
+
+        length = int.from_bytes(storage[:8], byteorder="little")
+        fp = rdkit.DataStructs.CreateFromBinaryText(storage[8:])
+        return fp
+
+    def encode(self, value):
+        if value is None:
+            return None
+        import rdkit
+
+        length_bytes = len(value).to_bytes(length=8, byteorder="little")
+        return length_bytes + rdkit.DataStructs.BitVectToBinaryText(value)
+
+
+class AbstractRDKitCountFingerprintValueFactory(kt.PythonValueFactory):
+    def __init__(self, dtype):
+        self._dtype = dtype
+        kt.PythonValueFactory.__init__(self, dtype)
+
+    def decode(self, storage):
+        if storage is None:
+            return None
+
+        # construct a new count fingerprint of type _dtype and fill it
+        sparse_vec = self._dtype(len(storage))
+        for i, v in enumerate(storage):
+            if v:
+                sparse_vec[i] = v
+        return sparse_vec
+
+    def encode(self, value):
+        if value is None:
+            return None
+
+        ba = bytearray(value.GetLength())
+        for idx, v in value.GetNonzeroElements().items():
+            ba[idx] = v
+        return ba
+
+
+class RDKitCountFingerprintValueFactoryUInt(AbstractRDKitCountFingerprintValueFactory):
+    def __init__(self):
+        super().__init__(UIntSparseIntVect)
+
+
+class RDKitCountFingerprintValueFactoryInt(AbstractRDKitCountFingerprintValueFactory):
+    def __init__(self):
+        super().__init__(IntSparseIntVect)
+
+
+class RDKitCountFingerprintValueFactoryULong(AbstractRDKitCountFingerprintValueFactory):
+    def __init__(self):
+        super().__init__(ULongSparseIntVect)
+
+
+class RDKitCountFingerprintValueFactoryLong(AbstractRDKitCountFingerprintValueFactory):
+    def __init__(self):
+        super().__init__(LongSparseIntVect)

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitAdapterCellValueFactory.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitAdapterCellValueFactory.java
@@ -1,0 +1,126 @@
+/*
+ * ------------------------------------------------------------------------
+ *
+ *  Copyright by KNIME AG, Zurich, Switzerland
+ *  Website: http://www.knime.com; Email: contact@knime.com
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License, Version 3, as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ *  Additional permission under GNU GPL version 3 section 7:
+ *
+ *  KNIME interoperates with ECLIPSE solely via ECLIPSE's plug-in APIs.
+ *  Hence, KNIME and ECLIPSE are both independent programs and are not
+ *  derived from each other. Should, however, the interpretation of the
+ *  GNU GPL Version 3 ("License") under any applicable laws result in
+ *  KNIME and ECLIPSE being a combined program, KNIME AG herewith grants
+ *  you the additional permission to use and propagate KNIME together with
+ *  ECLIPSE with only the license terms in place for ECLIPSE applying to
+ *  ECLIPSE and the GNU GPL Version 3 applying for KNIME, provided the
+ *  license terms of ECLIPSE themselves allow for the respective use and
+ *  propagation of ECLIPSE together with KNIME.
+ *
+ *  Additional permission relating to nodes for KNIME that extend the Node
+ *  Extension (and in particular that are based on subclasses of NodeModel,
+ *  NodeDialog, and NodeView) and that only interoperate with KNIME through
+ *  standard APIs ("Nodes"):
+ *  Nodes are deemed to be separate and independent programs and to not be
+ *  covered works.  Notwithstanding anything to the contrary in the
+ *  License, the License does not apply to Nodes, you are not required to
+ *  license Nodes under the License, and you are granted a license to
+ *  prepare and propagate Nodes, in each case even if such Nodes are
+ *  propagated with or for interoperation with KNIME.  The owner of a Node
+ *  may freely choose the license terms applicable to such Node, including
+ *  when such Node is propagated with or for interoperation with KNIME.
+ * ---------------------------------------------------------------------
+ *
+ * History
+ *   Oct 7, 2020 (dietzc): created
+ */
+package org.rdkit.knime.types;
+
+import java.io.IOException;
+
+import org.knime.core.data.AdapterCell;
+import org.knime.core.data.IDataRepository;
+import org.knime.core.data.filestore.internal.IWriteFileStoreHandler;
+import org.knime.core.data.v2.ReadValue;
+import org.knime.core.data.v2.ValueFactory;
+import org.knime.core.data.v2.WriteValue;
+import org.knime.core.data.v2.value.AbstractAdapterCellValueFactory;
+import org.knime.core.node.NodeLogger;
+import org.knime.core.table.access.ReadAccess;
+import org.knime.core.table.access.StructAccess.StructReadAccess;
+import org.knime.core.table.access.StructAccess.StructWriteAccess;
+import org.knime.core.table.access.VarBinaryAccess.VarBinaryReadAccess;
+import org.knime.core.table.access.VarBinaryAccess.VarBinaryWriteAccess;
+import org.knime.core.table.access.WriteAccess;
+import org.knime.core.table.schema.DataSpec;
+import org.knime.core.table.schema.VarBinaryDataSpec;
+
+/**
+ * A {@link ValueFactory} to support {@link RDKitAdapterCell}s in the columnar
+ * backend, and to support reading and writing from Python
+ * 
+ * @author Carsten Haubold, KNIME GmbH, Konstanz, Germany
+ */
+public class RDKitAdapterCellValueFactory extends AbstractAdapterCellValueFactory {
+
+	private static final NodeLogger LOGGER = NodeLogger.getLogger(RDKitAdapterCellValueFactory.class);
+	
+	@Override
+	public ReadValue createReadValue(StructReadAccess access) {
+		return new RDKitAdapterCellReadValue(access, m_dataRepository);
+	}
+
+	@Override
+	public WriteValue<?> createWriteValue(StructWriteAccess access) {
+		return new RDKitAdapterCellWriteValue(access, m_writeFileStoreHandler);
+	}
+
+	@Override
+	protected DataSpec getPrimarySpec() {
+		return VarBinaryDataSpec.INSTANCE;
+	}
+
+	private static final class RDKitAdapterCellWriteValue extends AbstractAdapterCellWriteValue<RDKitAdapterCell> {
+		private RDKitAdapterCellWriteValue(final StructWriteAccess access, final IWriteFileStoreHandler fsHandler) {
+			super(access, fsHandler);
+		}
+
+		@Override
+		protected void setPrimaryValue(final RDKitAdapterCell value, final WriteAccess writeAccess) {
+			try {
+				((VarBinaryWriteAccess) writeAccess).setByteArray(new RDKitMolSerializer().serialize(value));
+			} catch (IOException e) {
+				LOGGER.error("Error when serializing RDKitMolValue", e);
+			}
+		}
+	}
+
+	private static final class RDKitAdapterCellReadValue extends AbstractAdapterCellReadValue {
+		private RDKitAdapterCellReadValue(final StructReadAccess access, final IDataRepository dataRepository) {
+			super(access, dataRepository);
+		}
+		
+		@Override
+		protected AdapterCell getAdapterCell(final ReadAccess readAccess) {
+			try {
+				return (AdapterCell) (new RDKitMolDeserializer()
+						.deserialize(((VarBinaryReadAccess) readAccess).getByteArray(), null));
+			} catch (IOException e) {
+				LOGGER.error("Error when deserializing RDKitMolValue", e);
+				return null;
+			}
+		}
+	}
+}

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitMolCellValueFactory.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitMolCellValueFactory.java
@@ -1,0 +1,154 @@
+/*
+ * ------------------------------------------------------------------------
+ *
+ *  Copyright by KNIME AG, Zurich, Switzerland
+ *  Website: http://www.knime.com; Email: contact@knime.com
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License, Version 3, as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ *  Additional permission under GNU GPL version 3 section 7:
+ *
+ *  KNIME interoperates with ECLIPSE solely via ECLIPSE's plug-in APIs.
+ *  Hence, KNIME and ECLIPSE are both independent programs and are not
+ *  derived from each other. Should, however, the interpretation of the
+ *  GNU GPL Version 3 ("License") under any applicable laws result in
+ *  KNIME and ECLIPSE being a combined program, KNIME AG herewith grants
+ *  you the additional permission to use and propagate KNIME together with
+ *  ECLIPSE with only the license terms in place for ECLIPSE applying to
+ *  ECLIPSE and the GNU GPL Version 3 applying for KNIME, provided the
+ *  license terms of ECLIPSE themselves allow for the respective use and
+ *  propagation of ECLIPSE together with KNIME.
+ *
+ *  Additional permission relating to nodes for KNIME that extend the Node
+ *  Extension (and in particular that are based on subclasses of NodeModel,
+ *  NodeDialog, and NodeView) and that only interoperate with KNIME through
+ *  standard APIs ("Nodes"):
+ *  Nodes are deemed to be separate and independent programs and to not be
+ *  covered works.  Notwithstanding anything to the contrary in the
+ *  License, the License does not apply to Nodes, you are not required to
+ *  license Nodes under the License, and you are granted a license to
+ *  prepare and propagate Nodes, in each case even if such Nodes are
+ *  propagated with or for interoperation with KNIME.  The owner of a Node
+ *  may freely choose the license terms applicable to such Node, including
+ *  when such Node is propagated with or for interoperation with KNIME.
+ * ---------------------------------------------------------------------
+ *
+ * History
+ *   Oct 7, 2020 (dietzc): created
+ */
+package org.rdkit.knime.types;
+
+import java.io.IOException;
+
+import org.RDKit.ROMol;
+import org.knime.core.data.DataCell;
+import org.knime.core.data.v2.ReadValue;
+import org.knime.core.data.v2.ValueFactory;
+import org.knime.core.data.v2.WriteValue;
+import org.knime.core.node.NodeLogger;
+import org.knime.core.table.access.VarBinaryAccess.VarBinaryReadAccess;
+import org.knime.core.table.access.VarBinaryAccess.VarBinaryWriteAccess;
+import org.knime.core.table.schema.DataSpec;
+import org.knime.core.table.schema.VarBinaryDataSpec;
+
+/**
+ * The {@link ValueFactory} specifies how {@link RDKitMolValue}s are serialized
+ * in KNIME's Columnar Backend, which is needed also for communication with the
+ * Python (Labs) Scripting node and pure-Python nodes in KNIME.
+ * 
+ * Serialization into a binary blob works by using the
+ * {@link RDKitMolSerializer}.
+ * 
+ * @author Carsten Haubold, KNIME GmbH, Konstanz, Germany
+ */
+public class RDKitMolCellValueFactory implements ValueFactory<VarBinaryReadAccess, VarBinaryWriteAccess> { // NOSONAR:
+																											// cannot be
+																											// removed
+
+	private static final NodeLogger LOGGER = NodeLogger.getLogger(RDKitMolCellValueFactory.class);
+	/**
+	 * Stateless instance of this {@link RDKitMolCellValueFactory}.
+	 */
+	public static final RDKitMolCellValueFactory INSTANCE = new RDKitMolCellValueFactory();
+
+	@Override
+	public DataSpec getSpec() {
+		return VarBinaryDataSpec.INSTANCE;
+	}
+
+	private static final class RDKitMolCellWriteValue implements WriteValue<RDKitMolValue> {
+		private final VarBinaryWriteAccess m_access;
+
+		private RDKitMolCellWriteValue(final VarBinaryWriteAccess access) {
+			m_access = access;
+		}
+
+		public void setValue(final RDKitMolValue value) {
+			try {
+				m_access.setByteArray(new RDKitMolSerializer().serialize(value));
+			} catch (IOException e) {
+				LOGGER.error("Error when serializing RDKitMolValue", e);
+			}
+		}
+	}
+
+	private static final class RDKitMolCellReadValue implements ReadValue, RDKitMolValue {
+		private final VarBinaryReadAccess m_access;
+
+		private RDKitMolCellReadValue(final VarBinaryReadAccess access) {
+			m_access = access;
+		}
+
+		@Override
+		public DataCell getDataCell() {
+			try {
+				return new RDKitMolDeserializer().deserialize(m_access.getByteArray(), null);
+			} catch (IOException e) {
+				LOGGER.error("Error when deserializing RDKitMolValue", e);
+				return null;
+			}
+		}
+
+		@Override
+		public ROMol readMoleculeValue() {
+			// Note that these methods of the RDKitMolValue interface currently always
+			// cause a deserialization to happen. This is not very efficient, but necessary
+			// as the ReadValue is re-used when iterating over the rows of a KNIME table.
+			// An API to know whether a new value needs to be read is being developed.
+			// However, this is not a pressing issue yet as the ReadValues are not used
+			// directly yet but are passed to the BufferedDataTable using a single call to
+			// getDataCell().
+			return ((RDKitMolValue) getDataCell()).readMoleculeValue();
+		}
+
+		@Override
+		public String getSmilesValue() {
+			return ((RDKitMolValue) getDataCell()).getSmilesValue();
+		}
+
+		@Override
+		public boolean isSmilesCanonical() {
+			return ((RDKitMolValue) getDataCell()).isSmilesCanonical();
+		}
+	}
+
+	@Override
+	public ReadValue createReadValue(VarBinaryReadAccess access) {
+		return new RDKitMolCellReadValue(access);
+	}
+
+	@Override
+	public WriteValue<?> createWriteValue(VarBinaryWriteAccess access) {
+		return new RDKitMolCellWriteValue(access);
+	}
+}

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitReactionCellValueFactory.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitReactionCellValueFactory.java
@@ -1,0 +1,152 @@
+/*
+ * ------------------------------------------------------------------------
+ *
+ *  Copyright by KNIME AG, Zurich, Switzerland
+ *  Website: http://www.knime.com; Email: contact@knime.com
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License, Version 3, as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ *  Additional permission under GNU GPL version 3 section 7:
+ *
+ *  KNIME interoperates with ECLIPSE solely via ECLIPSE's plug-in APIs.
+ *  Hence, KNIME and ECLIPSE are both independent programs and are not
+ *  derived from each other. Should, however, the interpretation of the
+ *  GNU GPL Version 3 ("License") under any applicable laws result in
+ *  KNIME and ECLIPSE being a combined program, KNIME AG herewith grants
+ *  you the additional permission to use and propagate KNIME together with
+ *  ECLIPSE with only the license terms in place for ECLIPSE applying to
+ *  ECLIPSE and the GNU GPL Version 3 applying for KNIME, provided the
+ *  license terms of ECLIPSE themselves allow for the respective use and
+ *  propagation of ECLIPSE together with KNIME.
+ *
+ *  Additional permission relating to nodes for KNIME that extend the Node
+ *  Extension (and in particular that are based on subclasses of NodeModel,
+ *  NodeDialog, and NodeView) and that only interoperate with KNIME through
+ *  standard APIs ("Nodes"):
+ *  Nodes are deemed to be separate and independent programs and to not be
+ *  covered works.  Notwithstanding anything to the contrary in the
+ *  License, the License does not apply to Nodes, you are not required to
+ *  license Nodes under the License, and you are granted a license to
+ *  prepare and propagate Nodes, in each case even if such Nodes are
+ *  propagated with or for interoperation with KNIME.  The owner of a Node
+ *  may freely choose the license terms applicable to such Node, including
+ *  when such Node is propagated with or for interoperation with KNIME.
+ * ---------------------------------------------------------------------
+ *
+ * History
+ *   Oct 7, 2020 (dietzc): created
+ */
+package org.rdkit.knime.types;
+
+import java.io.IOException;
+
+import org.RDKit.ChemicalReaction;
+import org.knime.core.data.DataCell;
+import org.knime.core.data.v2.ReadValue;
+import org.knime.core.data.v2.ValueFactory;
+import org.knime.core.data.v2.WriteValue;
+import org.knime.core.node.NodeLogger;
+import org.knime.core.table.access.VarBinaryAccess.VarBinaryReadAccess;
+import org.knime.core.table.access.VarBinaryAccess.VarBinaryWriteAccess;
+import org.knime.core.table.schema.DataSpec;
+import org.knime.core.table.schema.VarBinaryDataSpec;
+
+/**
+ * The {@link ValueFactory} specifies how a {@link RDKitReactionValue} is
+ * serialized in KNIME's Columnar Backend, which is needed also for
+ * communication with the Python (Labs) Scripting node and pure-Python nodes in
+ * KNIME.
+ * 
+ * Serialization into a binary blob works by using the
+ * {@link RDKitReactionSerializer}.
+ * 
+ * @author Carsten Haubold, KNIME GmbH, Konstanz, Germany
+ */
+public class RDKitReactionCellValueFactory implements ValueFactory<VarBinaryReadAccess, VarBinaryWriteAccess> { // NOSONAR:
+																												// cannot
+																												// be
+																												// removed
+
+	private static final NodeLogger LOGGER = NodeLogger.getLogger(RDKitReactionCellValueFactory.class);
+
+	/**
+	 * Stateless instance of this {@link RDKitReactionCellValueFactory}.
+	 */
+	public static final RDKitReactionCellValueFactory INSTANCE = new RDKitReactionCellValueFactory();
+
+	@Override
+	public DataSpec getSpec() {
+		return VarBinaryDataSpec.INSTANCE;
+	}
+
+	private static final class RDKitReactionCellWriteValue implements WriteValue<RDKitReactionValue> {
+		private final VarBinaryWriteAccess m_access;
+
+		private RDKitReactionCellWriteValue(final VarBinaryWriteAccess access) {
+			m_access = access;
+		}
+
+		public void setValue(final RDKitReactionValue value) {
+			try {
+				m_access.setByteArray(new RDKitReactionSerializer().serialize(value));
+			} catch (IOException e) {
+				LOGGER.error("Error when serializing RDKitReactionValue", e);
+			}
+		}
+	}
+
+	private static final class RDKitReactionCellReadValue implements ReadValue, RDKitReactionValue {
+		private final VarBinaryReadAccess m_access;
+
+		private RDKitReactionCellReadValue(final VarBinaryReadAccess access) {
+			m_access = access;
+		}
+
+		@Override
+		public DataCell getDataCell() {
+			try {
+				return new RDKitReactionDeserializer().deserialize(m_access.getByteArray(), null);
+			} catch (IOException e) {
+				LOGGER.error("Error when deserializing RDKitMolValue", e);
+				return null;
+			}
+		}
+
+		@Override
+		public ChemicalReaction getReactionValue() {
+			// Note that these methods of the RDKitMolValue interface currently always
+			// cause a deserialization to happen. This is not very efficient, but necessary
+			// as the ReadValue is re-used when iterating over the rows of a KNIME table.
+			// An API to know whether a new value needs to be read is being developed.
+			// However, this is not a pressing issue yet as the ReadValues are not used
+			// directly yet but are passed to the BufferedDataTable using a single call to
+			// getDataCell().
+			return ((RDKitReactionValue) getDataCell()).getReactionValue();
+		}
+
+		@Override
+		public String getSmilesValue() {
+			return ((RDKitReactionValue) getDataCell()).getSmilesValue();
+		}
+	}
+
+	@Override
+	public ReadValue createReadValue(VarBinaryReadAccess access) {
+		return new RDKitReactionCellReadValue(access);
+	}
+
+	@Override
+	public WriteValue<RDKitReactionValue> createWriteValue(VarBinaryWriteAccess access) {
+		return new RDKitReactionCellWriteValue(access);
+	}
+}

--- a/org.rdkit.knime.wizards.feature/feature.xml
+++ b/org.rdkit.knime.wizards.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.wizards.feature"
       label="RDKit Nodes Creation Wizards Feature"
-      version="4.5.0.qualifier"
+      version="4.7.0.qualifier"
       provider-name="NIBR"
       plugin="org.rdkit.knime.wizards">
 

--- a/org.rdkit.knime.wizards.samples/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.wizards.samples/META-INF/MANIFEST.MF
@@ -3,13 +3,13 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Nodes Creation Wizards Samples
 Bundle-SymbolicName: org.rdkit.knime.wizards.samples;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.wizards.samples
-Bundle-Version: 4.5.0.qualifier
+Bundle-Version: 4.7.0.qualifier
 Bundle-Activator: org.rdkit.knime.wizards.samples.Activator
 Bundle-Vendor: NIBR
-Require-Bundle: org.knime.base;bundle-version="[4.3.0,5.0.0)";resolution:=optional,
- org.knime.chem.types;bundle-version="[4.3.0,5.0.0)";resolution:=optional,
- org.rdkit.knime.nodes;bundle-version="[4.5.0,5.0.0)";resolution:=optional,
- org.rdkit.knime.types;bundle-version="[4.5.0,5.0.0)";resolution:=optional,
+Require-Bundle: org.knime.base;bundle-version="[4.7.0,5.0.0)";resolution:=optional,
+ org.knime.chem.types;bundle-version="[4.7.0,5.0.0)";resolution:=optional,
+ org.rdkit.knime.nodes;bundle-version="[4.7.0,5.0.0)";resolution:=optional,
+ org.rdkit.knime.types;bundle-version="[4.7.0,5.0.0)";resolution:=optional,
  org.eclipse.ui;bundle-version="[3.116.0,4.0.0)";resolution:=optional,
  org.eclipse.core.runtime;bundle-version="[3.17.0,4.0.0)";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.rdkit.knime.wizards/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.wizards/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Nodes Creation Wizards
 Bundle-SymbolicName: org.rdkit.knime.wizards;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.wizards
-Bundle-Version: 4.5.0.qualifier
+Bundle-Version: 4.7.0.qualifier
 Bundle-Activator: org.rdkit.knime.wizards.RDKitNodesWizardsPlugin
 Bundle-Vendor: NIBR
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.7.0,4.0.0)",

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,19 @@
 			<plugins>
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-compiler-plugin</artifactId>
+					<version>${tycho.version}</version>
+					<configuration>
+						<compilerArgs>
+							<arg>--module-path</arg>
+							<arg>${java.home}/jmods</arg>
+							<arg>--add-modules</arg>
+							<arg>jdk.xml.dom</arg>
+						</compilerArgs>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>tycho-maven-plugin</artifactId>
 					<version>${tycho.version}</version>
 					<extensions>true</extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,9 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<revision>4.5.0</revision>
+		<revision>4.7.0</revision>
 		<changelist>-SNAPSHOT</changelist>
-		<knime.version>4.3</knime.version>
+		<knime.version>4.7</knime.version>
 		<tycho.version>1.5.1</tycho.version>
 		<tycho.extras.version>${tycho.version}</tycho.extras.version>
 		<qualifier.prefix>v</qualifier.prefix>


### PR DESCRIPTION
Hello Greg and Manuel,

This PR finally adds proper support for RDKit data types in KNIME's Columnar Backend, as well as in Python Scripting (Labs) nodes and pure-Python nodes. The changes rely on the latest KNIME 4.7 nightly, so this PR includes version bumps to build `knime-rdkit` for KNIME 4.7. 

You can find these changes in the first three commits. KNIME 4.7 will use a newer Eclipse version, which includes a version bump of several dependencies and is the reason why mixing plugins built for KNIME versions prior to 4.7 and plugins build for 4.7 and up will not work. See @gab1one's explanation here: https://forum.knime.com/t/update-to-eclipse-2022-06-for-knime-ap-4-7-0/46059.

To make RDKit types "native" types in the Columnar Backend, we need a `ValueFactory` for each type that wants to specify how it gets serialized. This PR adds `ValueFactories` for RDKitMolCell, RDKitAdapterCell and RDKitReactionCells. We have special `ValueFactories` in `org.knime.core` dealing with AdapterCells, allowing the `RDKitAdapterCellValueFactory` to be rather simple.

To make the RDKit types available in the new KNIME Python integration (`org.knime.python3`), we need to be able to read/write data to the same underlying format as in the corresponding Java `ValueFactory`. We have `PythonValueFactories` for that. For molecules and reactions this relies purely on RDKit functionality, but fingerprints are serialized using KNIME's `DenseBitVector` and `DenseByteVector`. To make it easy to work with those types with RDKit, we implemented "extension type casting". This means you can cast a `DenseByteVector` column in a pandas DataFrame to a `UIntSparseIntVect` and use that for further processing. The type cast basically allows to swap which deserializer of the underlying data is used when accessing the values. So after casting the column to `UIntSparseIntVect`, it will use the deserializer for `UIntSparseIntVect` instead of the one for `DenseByteVector`.

Here is a test workflow where I compare the results of using native KNIME nodes or Python Script (Labs) nodes to work with RDKit molecules, reactions and fingerprints. The last two Python Script nodes show type casting in action. https://drive.google.com/file/d/1aRNzBNDm4prIBngLwRswMB2C82zvcBVW/view?usp=sharing

**Note:** all of this is using the latest functionality in KNIME's 4.7 nightly, some of which were only merged yesterday. So make sure to use an up to date KNIME nightly and/or target platform when trying this.

Cheers,
Carsten