### PR TITLE
Add new folder to build.properties

### DIFF
--- a/org.rdkit.knime.types/build.properties
+++ b/org.rdkit.knime.types/build.properties
@@ -5,7 +5,8 @@ bin.includes = META-INF/,\
                plugin.xml,\
                python/,\
                schema/,\
-               rdkit-chem.jar
+               rdkit-chem.jar,\
+               python3/
 jars.extra.classpath = lib/org.RDKit.jar, lib/org.RDKitDoc.jar
 jars.compile.order = rdkit-chem.jar
 source.rdkit-chem.jar = rdkit-chemsrc/


### PR DESCRIPTION
Hi @manuelschwarze,

I'm sorry, I noticed that I forgot to include one important change in my last PR: the new Python file was not added to the `build.properties` and thus did not get installed into KNIME. Here's the fix.

Best,
Carsten