### PR TITLE
Add value type names for extension types

### DIFF
--- a/org.rdkit.knime.types/plugin.xml
+++ b/org.rdkit.knime.types/plugin.xml
@@ -158,39 +158,47 @@
             modulePath="python3" moduleName="knime.types.ext.rdkit">
          <PythonValueFactory
                PythonClassName="RDKitMolValueFactory"
-               ValueFactory="org.rdkit.knime.types.RDKitMolCellValueFactory">
+               ValueFactory="org.rdkit.knime.types.RDKitMolCellValueFactory"
+               ValueTypeName="rdkit.Chem.rdchem.Mol">
          </PythonValueFactory>
          <PythonValueFactory
                PythonClassName="RDKitMolAdapterValueFactory"
-               ValueFactory="org.rdkit.knime.types.RDKitAdapterCellValueFactory">
+               ValueFactory="org.rdkit.knime.types.RDKitAdapterCellValueFactory"
+               ValueTypeName="rdkit.Chem.rdchem.Mol">
          </PythonValueFactory>
          <PythonValueFactory
                PythonClassName="RDKitReactionValueFactory"
-               ValueFactory="org.rdkit.knime.types.RDKitReactionCellValueFactory">
+               ValueFactory="org.rdkit.knime.types.RDKitReactionCellValueFactory"
+               ValueTypeName="rdkit.Chem.rdChemReactions.ChemicalReaction">
          </PythonValueFactory>
          <PythonValueFactory
                PythonClassName="RDKitFingerprintValueFactory"
                ValueFactory="org.knime.core.data.v2.value.DenseBitVectorValueFactory"
+               ValueTypeName="rdkit.DataStructs.cDataStructs.ExplicitBitVect"
                isDefaultPythonRepresentation="false">
          </PythonValueFactory>
          <PythonValueFactory
                PythonClassName="RDKitCountFingerprintValueFactoryUInt"
                ValueFactory="org.knime.core.data.v2.value.DenseByteVectorValueFactory"
+               ValueTypeName="rdkit.DataStructs.cDataStructs.UIntSparseIntVect"
                isDefaultPythonRepresentation="false">
          </PythonValueFactory>
          <PythonValueFactory
                PythonClassName="RDKitCountFingerprintValueFactoryInt"
                ValueFactory="org.knime.core.data.v2.value.DenseByteVectorValueFactory"
+               ValueTypeName="rdkit.DataStructs.cDataStructs.IntSparseIntVect"
                isDefaultPythonRepresentation="false">
          </PythonValueFactory>
          <PythonValueFactory
                PythonClassName="RDKitCountFingerprintValueFactoryULong"
                ValueFactory="org.knime.core.data.v2.value.DenseByteVectorValueFactory"
+               ValueTypeName="rdkit.DataStructs.cDataStructs.ULongSparseIntVect"
                isDefaultPythonRepresentation="false">
          </PythonValueFactory>
          <PythonValueFactory
                PythonClassName="RDKitCountFingerprintValueFactoryLong"
                ValueFactory="org.knime.core.data.v2.value.DenseByteVectorValueFactory"
+               ValueTypeName="rdkit.DataStructs.cDataStructs.LongSparseIntVect"
                isDefaultPythonRepresentation="false">
          </PythonValueFactory>
       </Module>

--- a/org.rdkit.knime.types/python3/knime/types/ext/rdkit.py
+++ b/org.rdkit.knime.types/python3/knime/types/ext/rdkit.py
@@ -49,7 +49,7 @@ are read and written from/to the underlying table in Python.
 @author Carsten Haubold, KNIME GmbH, Konstanz, Germany
 """
 import logging
-import knime_types as kt
+import knime.api.types as kt
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
We implemented lazy loading of the modules containing the Python value factories in the KAP nightly for 4.7. For this, the schema  requires a string representation of the value type name to enable lazy lookup.