### PR TITLE
Refactor serializers to remove interdependencies of Python integrations

### DIFF
--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitAdapterCellValueFactory.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitAdapterCellValueFactory.java
@@ -76,7 +76,7 @@ import org.knime.core.table.schema.VarBinaryDataSpec;
 public class RDKitAdapterCellValueFactory extends AbstractAdapterCellValueFactory {
 
 	private static final NodeLogger LOGGER = NodeLogger.getLogger(RDKitAdapterCellValueFactory.class);
-	
+
 	@Override
 	public ReadValue createReadValue(StructReadAccess access) {
 		return new RDKitAdapterCellReadValue(access, m_dataRepository);
@@ -100,7 +100,7 @@ public class RDKitAdapterCellValueFactory extends AbstractAdapterCellValueFactor
 		@Override
 		protected void setPrimaryValue(final RDKitAdapterCell value, final WriteAccess writeAccess) {
 			try {
-				((VarBinaryWriteAccess) writeAccess).setByteArray(new RDKitMolSerializer().serialize(value));
+				((VarBinaryWriteAccess) writeAccess).setByteArray(RDKitTypeSerializationUtils.serializeMolValue(value));
 			} catch (IOException e) {
 				LOGGER.error("Error when serializing RDKitMolValue", e);
 			}
@@ -111,12 +111,12 @@ public class RDKitAdapterCellValueFactory extends AbstractAdapterCellValueFactor
 		private RDKitAdapterCellReadValue(final StructReadAccess access, final IDataRepository dataRepository) {
 			super(access, dataRepository);
 		}
-		
+
 		@Override
 		protected AdapterCell getAdapterCell(final ReadAccess readAccess) {
 			try {
-				return (AdapterCell) (new RDKitMolDeserializer()
-						.deserialize(((VarBinaryReadAccess) readAccess).getByteArray(), null));
+				return (AdapterCell) (RDKitTypeSerializationUtils
+						.deserializeMolCell2(((VarBinaryReadAccess) readAccess).getByteArray()));
 			} catch (IOException e) {
 				LOGGER.error("Error when deserializing RDKitMolValue", e);
 				return null;

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitMolCellValueFactory.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitMolCellValueFactory.java
@@ -95,7 +95,7 @@ public class RDKitMolCellValueFactory implements ValueFactory<VarBinaryReadAcces
 
 		public void setValue(final RDKitMolValue value) {
 			try {
-				m_access.setByteArray(new RDKitMolSerializer().serialize(value));
+				m_access.setByteArray(RDKitTypeSerializationUtils.serializeMolValue(value));
 			} catch (IOException e) {
 				LOGGER.error("Error when serializing RDKitMolValue", e);
 			}
@@ -112,7 +112,7 @@ public class RDKitMolCellValueFactory implements ValueFactory<VarBinaryReadAcces
 		@Override
 		public DataCell getDataCell() {
 			try {
-				return new RDKitMolDeserializer().deserialize(m_access.getByteArray(), null);
+				return RDKitTypeSerializationUtils.deserializeMolCell2(m_access.getByteArray());
 			} catch (IOException e) {
 				LOGGER.error("Error when deserializing RDKitMolValue", e);
 				return null;

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitMolDeserializer.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitMolDeserializer.java
@@ -2,11 +2,8 @@ package org.rdkit.knime.types;
 
 import java.io.IOException;
 
-import org.RDKit.ROMol;
 import org.knime.core.data.DataCell;
-import org.knime.core.data.DataType;
 import org.knime.core.data.filestore.FileStoreFactory;
-import org.knime.core.node.NodeLogger;
 import org.knime.python.typeextension.Deserializer;
 import org.knime.python.typeextension.DeserializerFactory;
 
@@ -39,51 +36,12 @@ public class RDKitMolDeserializer implements Deserializer {
 	}
 
 	//
-	// Constants
-	//
-
-	/** The logging instance. */
-	private static final NodeLogger LOGGER = NodeLogger.getLogger(RDKitMolDeserializer.class);
-
-	//
 	// Public Methods
 	//
 
 	@Override
 	public DataCell deserialize(final byte[] bytes, final FileStoreFactory fileStoreFactory) throws IOException {
-		DataCell cell;
-
-		// Generate missing cell, if input is unavailable
-		if (bytes == null || bytes.length == 0) {
-			cell = DataType.getMissingCell();
-		}
-
-		// Generate an RDKit Mol Cell with canonicalized SMILES attached
-		else {
-			ROMol mol = null;
-			try {
-				mol = RDKitMolCell2.toROMol(bytes);
-				cell = RDKitMolCellFactory.createRDKitAdapterCell(mol, null);
-			}
-			catch (final Exception exc) {
-				LOGGER.debug(exc);
-
-				// In case of an error throw an IOException
-				String strMsg = exc.getMessage();
-				if (strMsg == null || strMsg.trim().isEmpty()) {
-					strMsg = "Unknown error";
-				}
-				throw new IOException("Unable to interpret RDKit Molecule: " + strMsg);
-
-			}
-			finally {
-				if (mol != null) {
-					mol.delete();
-				}
-			}
-		}
-
-		return cell;
+		return RDKitTypeSerializationUtils.deserializeMolCell2(bytes);
 	}
 
 }

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitMolSerializer.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitMolSerializer.java
@@ -2,7 +2,6 @@ package org.rdkit.knime.types;
 
 import java.io.IOException;
 
-import org.RDKit.ROMol;
 import org.knime.python.typeextension.Serializer;
 import org.knime.python.typeextension.SerializerFactory;
 
@@ -48,30 +47,6 @@ public class RDKitMolSerializer implements Serializer<RDKitMolValue> {
 	 */
 	@Override
 	public byte[] serialize(final RDKitMolValue value) throws IOException {
-		byte[] arrBinaryMolecule = null;
-
-		if (value != null) {
-			// Shortcut for the normal case that we have a normal RDKit Mol Cell
-			if (value instanceof RDKitMolCell2) {
-				arrBinaryMolecule = ((RDKitMolCell2)value).getBinaryValue();
-			}
-
-			// Longer way if we have a different implementation (e.g. Adapter Cell), which is slower but always works
-			else {
-				ROMol mol = null;
-
-				try {
-					mol = value.readMoleculeValue();
-					arrBinaryMolecule = RDKitMolCell2.toByteArray(mol);
-				}
-				finally {
-					if (mol != null) {
-						mol.delete();
-					}
-				}
-			}
-		}
-
-		return arrBinaryMolecule;
+		return RDKitTypeSerializationUtils.serializeMolValue(value);
 	}
 }

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitReactionCellValueFactory.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitReactionCellValueFactory.java
@@ -98,7 +98,7 @@ public class RDKitReactionCellValueFactory implements ValueFactory<VarBinaryRead
 
 		public void setValue(final RDKitReactionValue value) {
 			try {
-				m_access.setByteArray(new RDKitReactionSerializer().serialize(value));
+				m_access.setByteArray(RDKitTypeSerializationUtils.serializeReactionValue(value));
 			} catch (IOException e) {
 				LOGGER.error("Error when serializing RDKitReactionValue", e);
 			}
@@ -115,7 +115,7 @@ public class RDKitReactionCellValueFactory implements ValueFactory<VarBinaryRead
 		@Override
 		public DataCell getDataCell() {
 			try {
-				return new RDKitReactionDeserializer().deserialize(m_access.getByteArray(), null);
+				return RDKitTypeSerializationUtils.deserializeReactionCell(m_access.getByteArray());
 			} catch (IOException e) {
 				LOGGER.error("Error when deserializing RDKitMolValue", e);
 				return null;

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitReactionDeserializer.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitReactionDeserializer.java
@@ -2,11 +2,8 @@ package org.rdkit.knime.types;
 
 import java.io.IOException;
 
-import org.RDKit.ChemicalReaction;
 import org.knime.core.data.DataCell;
-import org.knime.core.data.DataType;
 import org.knime.core.data.filestore.FileStoreFactory;
-import org.knime.core.node.NodeLogger;
 import org.knime.python.typeextension.Deserializer;
 import org.knime.python.typeextension.DeserializerFactory;
 
@@ -39,44 +36,12 @@ public class RDKitReactionDeserializer implements Deserializer {
 	}
 
 	//
-	// Constants
-	//
-
-	/** The logging instance. */
-	private static final NodeLogger LOGGER = NodeLogger.getLogger(RDKitReactionDeserializer.class);
-
-	//
 	// Public Methods
 	//
 
 	@Override
 	public DataCell deserialize(final byte[] bytes, final FileStoreFactory fileStoreFactory) throws IOException {
-		DataCell cell;
-
-		// Generate missing cell, if input is unavailable
-		if (bytes == null || bytes.length == 0) {
-			cell = DataType.getMissingCell();
-		}
-
-		// Generate an RDKit Reaction Cell
-		else {
-			try {
-				final ChemicalReaction reaction = RDKitReactionCell.toChemicalReaction(bytes);
-				cell = new RDKitReactionCell(reaction);
-			}
-			catch (final Exception exc) {
-				LOGGER.debug(exc);
-				// In case of an error throw an IOException
-				String strMsg = exc.getMessage();
-				if (strMsg == null || strMsg.trim().isEmpty()) {
-					strMsg = "Unknown error";
-				}
-				throw new IOException("Unable to interpret RDKit Reaction: " + strMsg);
-			}
-			// Note: Do not delete the reaction object here, because it is used in the cell
-		}
-
-		return cell;
+		return RDKitTypeSerializationUtils.deserializeReactionCell(bytes);
 	}
 
 }

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitReactionSerializer.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitReactionSerializer.java
@@ -2,7 +2,6 @@ package org.rdkit.knime.types;
 
 import java.io.IOException;
 
-import org.RDKit.ChemicalReaction;
 import org.knime.python.typeextension.Serializer;
 import org.knime.python.typeextension.SerializerFactory;
 
@@ -48,14 +47,6 @@ public class RDKitReactionSerializer implements Serializer<RDKitReactionValue> {
 	 */
 	@Override
 	public byte[] serialize(final RDKitReactionValue value) throws IOException {
-		byte[] arrBinaryReaction = null;
-
-		if (value != null) {
-			final ChemicalReaction reaction = value.getReactionValue();
-			arrBinaryReaction = RDKitReactionCell.toByteArray(reaction);
-			// Note: Do not delete the reaction object here, because it is a reference to real cell content
-		}
-
-		return arrBinaryReaction;
+		return RDKitTypeSerializationUtils.serializeReactionValue(value);
 	}
 }

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitTypeSerializationUtils.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitTypeSerializationUtils.java
@@ -1,0 +1,134 @@
+package org.rdkit.knime.types;
+
+import java.io.IOException;
+
+import org.RDKit.ChemicalReaction;
+import org.RDKit.ROMol;
+import org.knime.core.data.DataCell;
+import org.knime.core.data.DataType;
+import org.knime.core.node.NodeLogger;
+
+/**
+ * Serialization methods used by KNIME for the old Python integrations (org.knime.python and org.knime.python2),
+ * as well as the Columnar Backend and the current Python integration (org.knime.python3).
+ * 
+ * The methods live in a separate class because the "old" and "current" Python integrations are both optional and
+ * should not depend on each other, so the shared functionality must live outside of both.
+ * 
+ * @author Carsten Haubold, KNIME GmbH, Konstanz, Germany
+ */
+public class RDKitTypeSerializationUtils { 
+	//
+	// Constants
+	//
+	private static final NodeLogger LOGGER = NodeLogger.getLogger(RDKitTypeSerializationUtils.class);
+	
+	
+	//
+	// Public Methods
+	//
+	public static DataCell deserializeMolCell2(final byte[] bytes) throws IOException {
+		DataCell cell;
+
+		// Generate missing cell, if input is unavailable
+		if (bytes == null || bytes.length == 0) {
+			cell = DataType.getMissingCell();
+		}
+
+		// Generate an RDKit Mol Cell with canonicalized SMILES attached
+		else {
+			ROMol mol = null;
+			try {
+				mol = RDKitMolCell2.toROMol(bytes);
+				cell = RDKitMolCellFactory.createRDKitAdapterCell(mol, null);
+			}
+			catch (final Exception exc) {
+				LOGGER.debug(exc);
+
+				// In case of an error throw an IOException
+				String strMsg = exc.getMessage();
+				if (strMsg == null || strMsg.trim().isEmpty()) {
+					strMsg = "Unknown error";
+				}
+				throw new IOException("Unable to interpret RDKit Molecule: " + strMsg);
+
+			}
+			finally {
+				if (mol != null) {
+					mol.delete();
+				}
+			}
+		}
+
+		return cell;
+	}
+	
+	public static byte[] serializeMolValue(RDKitMolValue value) throws IOException {
+		byte[] arrBinaryMolecule = null;
+
+		if (value != null) {
+			// Shortcut for the normal case that we have a normal RDKit Mol Cell
+			if (value instanceof RDKitMolCell2) {
+				arrBinaryMolecule = ((RDKitMolCell2)value).getBinaryValue();
+			}
+
+			// Longer way if we have a different implementation (e.g. Adapter Cell), which is slower but always works
+			else {
+				ROMol mol = null;
+
+				try {
+					mol = value.readMoleculeValue();
+					arrBinaryMolecule = RDKitMolCell2.toByteArray(mol);
+				}
+				finally {
+					if (mol != null) {
+						mol.delete();
+					}
+				}
+			}
+		}
+
+		return arrBinaryMolecule;
+	}
+	
+	public static byte[] serializeReactionValue(final RDKitReactionValue value) throws IOException {
+		byte[] arrBinaryReaction = null;
+
+		if (value != null) {
+			final ChemicalReaction reaction = value.getReactionValue();
+			arrBinaryReaction = RDKitReactionCell.toByteArray(reaction);
+			// Note: Do not delete the reaction object here, because it is a reference to real cell content
+		}
+
+		return arrBinaryReaction;
+	}
+	
+	public static DataCell deserializeReactionCell(final byte[] bytes) throws IOException {
+		DataCell cell;
+
+		// Generate missing cell, if input is unavailable
+		if (bytes == null || bytes.length == 0) {
+			cell = DataType.getMissingCell();
+		}
+
+		// Generate an RDKit Reaction Cell
+		else {
+			try {
+				final ChemicalReaction reaction = RDKitReactionCell.toChemicalReaction(bytes);
+				cell = new RDKitReactionCell(reaction);
+			}
+			catch (final Exception exc) {
+				LOGGER.debug(exc);
+				// In case of an error throw an IOException
+				String strMsg = exc.getMessage();
+				if (strMsg == null || strMsg.trim().isEmpty()) {
+					strMsg = "Unknown error";
+				}
+				throw new IOException("Unable to interpret RDKit Reaction: " + strMsg);
+			}
+			// Note: Do not delete the reaction object here, because it is used in the cell
+		}
+
+		return cell;
+	}
+}


### PR DESCRIPTION
The "new" KNIME Python integration and the columnar backend use the serialization as defined by the ValueFactories. These were re-using the serialization methods from the Serializers and Deserializers for the "old" Python integration, which unfortunately introduced a dependency to the old Python integration.

This means up to now the old Python integration had to be installed for the RDKit types to work in the "new" Python integration and the columnar backend. In most cases this was no issue, because both Python integrations are installed together in KNIME (there are more dependencies on the UI side), but when developing pure-Python nodes that use RDKit extension types we don't want to have a dependency on the "old" Python integration.

This commmit extracts the shared serialization methods into a utility class, breaking the aforementioned dependency.

@greglandrum or @manuelschwarze could you please have a look so that we can fix this issue before KNIME 4.7 is released? Thank you!