### PR TITLE
KNIME-1473: Updated OPSIN to fix CVE-2022-40152 (com.fasterxml.woodstox)

### DIFF
--- a/org.rdkit.knime.nodes/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.nodes/META-INF/MANIFEST.MF
@@ -61,5 +61,5 @@ Export-Package: org.rdkit.knime.nodes,
 Bundle-Activator: org.rdkit.knime.nodes.RDKitNodePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,
- lib/opsin-core-3.0-SNAPSHOT-2022-07-04-jar-with-dependencies.jar
+ lib/opsin-core-3.0-SNAPSHOT-2022-12-06-jar-with-dependencies.jar
 Import-Package: org.w3c.dom.events;version="3.0.0"

--- a/org.rdkit.knime.nodes/build.properties
+++ b/org.rdkit.knime.nodes/build.properties
@@ -4,7 +4,7 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               lib/opsin-core-3.0-SNAPSHOT-2022-07-04-jar-with-dependencies.jar,\
+               lib/opsin-core-3.0-SNAPSHOT-2022-12-06-jar-with-dependencies.jar,\
                icons/
-jars.extra.classpath = lib/opsin-core-3.0-SNAPSHOT-2022-07-04-jar-with-dependencies.jar,\
+jars.extra.classpath = lib/opsin-core-3.0-SNAPSHOT-2022-12-06-jar-with-dependencies.jar,\
 					   platform:/plugin/org.rdkit.knime.types/lib/org.RDKit.jar


### PR DESCRIPTION
Updated OPSIN to latest version, which incl. security fix. Tests are running through fine. Tested on Linux.