### PR TITLE
Feature/python3 knime4.7 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin
 /org.rdkit.knime.types/python/*.pyc
+**/__pycache__/
 /.metadata/
 .polyglot.feature.xml.takari_issue_192
 .polyglot..META-INF_MANIFEST.MF

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extensions>
     <extension>
-        <groupId>org.eclipse.tycho.extras</groupId>
-        <artifactId>tycho-pomless</artifactId>
-        <version>1.5.1</version>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-build</artifactId>
+        <version>2.7.3</version>
     </extension>
 </extensions>

--- a/org.knime.sdk.setup/KNIME-AP-4.7.target
+++ b/org.knime.sdk.setup/KNIME-AP-4.7.target
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target includeMode="feature" name="KNIME Analytics Platform 4.7">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="com.knime.features.explorer.serverspace.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.base.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.browser.cef.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.core.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.chem.types.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.database.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.dbdrivers.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.ensembles.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.ext.itemset.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.ext.jep.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.ext.poi.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.javasnippet.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.json.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.js.quickforms.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.personalproductivity.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.stats.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.python2.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.testing.application.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.timeseries.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.workbench.feature.group" version="0.0.0"/>
+<unit id="org.knime.features.xml.feature.group" version="0.0.0"/>
+<unit id="org.knime.targetPlatform.feature.group" version="0.0.0"/>
+<repository location="http://update.knime.org/analytics-platform/4.7/"/>
+</location>
+</locations>
+</target>

--- a/org.rdkit.knime.bin.linux.x86_64/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.bin.linux.x86_64/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDKit binaries for 64bit Linux
 Bundle-SymbolicName: org.rdkit.knime.bin.linux.x86_64;singleton:=true
-Bundle-Version: 4.6.1.qualifier
-Fragment-Host: org.rdkit.knime.types;bundle-version="4.6.1"
+Bundle-Version: 4.7.0.qualifier
+Fragment-Host: org.rdkit.knime.types;bundle-version="4.7.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-PlatformFilter: (&(osgi.os=linux)(osgi.arch=x86_64))
 Bundle-Vendor: NIBR

--- a/org.rdkit.knime.bin.macosx.aarch64/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.bin.macosx.aarch64/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDKit binaries for Apple Silicon 64bit MacOSX
 Bundle-SymbolicName: org.rdkit.knime.bin.macosx.aarch64;singleton:=true
-Bundle-Version: 4.6.1.qualifier
-Fragment-Host: org.rdkit.knime.types;bundle-version="4.6.1"
+Bundle-Version: 4.7.0.qualifier
+Fragment-Host: org.rdkit.knime.types;bundle-version="4.7.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-PlatformFilter: (&(osgi.os=macosx)(osgi.arch=aarch64))
 Bundle-Vendor: NIBR

--- a/org.rdkit.knime.bin.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.bin.macosx.x86_64/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDKit binaries for Intel 64bit MacOSX
 Bundle-SymbolicName: org.rdkit.knime.bin.macosx.x86_64;singleton:=true
-Bundle-Version: 4.6.1.qualifier
-Fragment-Host: org.rdkit.knime.types;bundle-version="4.6.1"
+Bundle-Version: 4.7.0.qualifier
+Fragment-Host: org.rdkit.knime.types;bundle-version="4.7.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-PlatformFilter: (&(osgi.os=macosx)(osgi.arch=x86_64))
 Bundle-Vendor: NIBR

--- a/org.rdkit.knime.bin.win32.x86_64/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.bin.win32.x86_64/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDKit binaries for 64bit Windows
 Bundle-SymbolicName: org.rdkit.knime.bin.win32.x86_64;singleton:=true
-Bundle-Version: 4.6.1.qualifier
-Fragment-Host: org.rdkit.knime.types;bundle-version="4.6.1"
+Bundle-Version: 4.7.0.qualifier
+Fragment-Host: org.rdkit.knime.types;bundle-version="4.7.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-PlatformFilter: (&(osgi.os=win32)(osgi.arch=x86_64))
 Bundle-Vendor: NIBR

--- a/org.rdkit.knime.binaries.feature/feature.xml
+++ b/org.rdkit.knime.binaries.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.binaries.feature"
       label="RDKit Binaries and Chemistry Type Definitions Feature"
-      version="4.6.1.qualifier"
+      version="4.7.0.qualifier"
       provider-name="NIBR">
 
    <description>

--- a/org.rdkit.knime.binaries.feature/feature.xml
+++ b/org.rdkit.knime.binaries.feature/feature.xml
@@ -714,6 +714,15 @@ Public License instead of this License.  But first, please read
          fragment="true"/>
 
    <plugin
+         id="org.rdkit.knime.bin.macosx.aarch64"
+         os="macosx"
+         arch="aarch64"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"/>
+
+   <plugin
          id="org.rdkit.knime.bin.win32.x86_64"
          os="win32"
          arch="x86_64"

--- a/org.rdkit.knime.feature/feature.xml
+++ b/org.rdkit.knime.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.feature"
       label="RDKit Nodes Feature"
-      version="4.6.1.qualifier"
+      version="4.7.0.qualifier"
       provider-name="NIBR"
       plugin="org.rdkit.knime.nodes">
 

--- a/org.rdkit.knime.nodes/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.nodes/META-INF/MANIFEST.MF
@@ -3,15 +3,15 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Nodes
 Bundle-SymbolicName: org.rdkit.knime.nodes;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.nodes
-Bundle-Version: 4.6.1.qualifier
+Bundle-Version: 4.7.0.qualifier
 Bundle-Vendor: NIBR
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.ui;bundle-version="[3.109.0,4.0.0)",
- org.knime.base;bundle-version="[4.6.0,5.0.0)",
- org.knime.chem.types;bundle-version="[4.6.0,5.0.0)",
- org.knime.workbench.repository;bundle-version="[4.6.0,5.0.0)",
- org.rdkit.knime.types;bundle-version="[4.6.1,5.0.0)",
- org.knime.ext.svg;bundle-version="[4.6.0,5.0.0)"
+ org.knime.base;bundle-version="[4.7.0,5.0.0)",
+ org.knime.chem.types;bundle-version="[4.7.0,5.0.0)",
+ org.knime.workbench.repository;bundle-version="[4.7.0,5.0.0)",
+ org.rdkit.knime.types;bundle-version="[4.7.0,5.0.0)",
+ org.knime.ext.svg;bundle-version="[4.7.0,5.0.0)"
 Export-Package: org.rdkit.knime.nodes,
  org.rdkit.knime.nodes.addconformers,
  org.rdkit.knime.nodes.addcoordinates;uses:="org.knime.core.node,org.knime.core.node.defaultnodesettings",
@@ -62,4 +62,3 @@ Bundle-Activator: org.rdkit.knime.nodes.RDKitNodePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,
  lib/opsin-core-3.0-SNAPSHOT-2022-12-06-jar-with-dependencies.jar
-Import-Package: org.w3c.dom.events;version="3.0.0"

--- a/org.rdkit.knime.testing.feature/feature.xml
+++ b/org.rdkit.knime.testing.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.testing.feature"
       label="RDKit Nodes Tests Feature"
-      version="4.6.1.qualifier"
+      version="4.7.0.qualifier"
       provider-name="NIBR">
 
    <description>

--- a/org.rdkit.knime.testing/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.testing/META-INF/MANIFEST.MF
@@ -3,10 +3,10 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Nodes Tests
 Bundle-SymbolicName: org.rdkit.knime.testing;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.testing
-Bundle-Version: 4.6.1.qualifier
+Bundle-Version: 4.7.0.qualifier
 Bundle-Vendor: NIBR
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Fragment-Host: org.rdkit.knime.nodes;bundle-version="4.6.1"
-Require-Bundle: org.knime.testing;bundle-version="[4.6.0,5.0.0)",
- org.knime.chem.base;bundle-version="[4.6.0,5.0.0)"
+Fragment-Host: org.rdkit.knime.nodes;bundle-version="4.7.0"
+Require-Bundle: org.knime.testing;bundle-version="[4.7.0,5.0.0)",
+ org.knime.chem.base;bundle-version="[4.7.0,5.0.0)"
 Bundle-ClassPath: rdkit-testing.jar

--- a/org.rdkit.knime.types/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.types/META-INF/MANIFEST.MF
@@ -5,24 +5,26 @@ Export-Package: org.RDKit,
  org.rdkit.knime.types,
  org.rdkit.knime.types.preferences,
  org.rdkit.knime.util
-Require-Bundle: org.knime.base;bundle-version="[4.6.0,5.0.0)",
+Require-Bundle: org.knime.base;bundle-version="[4.7.0,5.0.0)",
  org.eclipse.osgi;bundle-version="[3.12.100,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.13.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.109.0,4.0.0)",
- org.knime.ext.svg;bundle-version="[4.6.0,5.0.0)",
- org.apache.batik.dom.svg;bundle-version="[1.13.0,1.14.0)",
- org.apache.batik.util;bundle-version="[1.13.0,1.14.0)",
- org.knime.chem.types;bundle-version="[4.6.0,5.0.0)",
- org.knime.workbench.repository;bundle-version="[4.6.0,5.0.0)",
- org.knime.workbench.ui;bundle-version="[4.6.0,5.0.0)",
- org.knime.python.typeextensions;bundle-version="[4.6.0,5.0.0)";resolution:=optional,
+ org.knime.ext.svg;bundle-version="[4.7.0,5.0.0)",
+ org.apache.batik.dom.svg;bundle-version="[1.13.0,2.0.0)",
+ org.apache.batik.util;bundle-version="[1.13.0,2.0.0)",
+ org.knime.chem.types;bundle-version="[4.7.0,5.0.0)",
+ org.knime.workbench.repository;bundle-version="[4.7.0,5.0.0)",
+ org.knime.workbench.ui;bundle-version="[4.7.0,5.0.0)",
+ org.knime.python.typeextensions;bundle-version="[4.7.0,5.0.0)";resolution:=optional,
  com.google.gson;bundle-version="[2.8.6,3.0.0)"
+ org.knime.core.table;bundle-version="[4.7.0,5.0.0)",
+ org.knime.python3.types;bundle-version="[4.7.0,5.0.0)";resolution:=optional
 Bundle-Vendor: NIBR
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: rdkit-chem.jar,
  lib/org.RDKit.jar,
  lib/org.RDKitDoc.jar
-Bundle-Version: 4.6.1.qualifier
+Bundle-Version: 4.7.0.qualifier
 Bundle-Name: RDKit Chemistry Type Definitions
 Bundle-Activator: org.rdkit.knime.RDKitTypesPluginActivator
 Bundle-ManifestVersion: 2
@@ -30,4 +32,3 @@ Bundle-SymbolicName: org.rdkit.knime.types;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.types
 Eclipse-RegisterBuddy: org.knime.base
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Import-Package: org.w3c.dom.events;version="3.0.0"

--- a/org.rdkit.knime.types/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.types/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Require-Bundle: org.knime.base;bundle-version="[4.7.0,5.0.0)",
  org.knime.workbench.repository;bundle-version="[4.7.0,5.0.0)",
  org.knime.workbench.ui;bundle-version="[4.7.0,5.0.0)",
  org.knime.python.typeextensions;bundle-version="[4.7.0,5.0.0)";resolution:=optional,
- com.google.gson;bundle-version="[2.8.6,3.0.0)"
+ com.google.gson;bundle-version="[2.8.6,3.0.0)",
  org.knime.core.table;bundle-version="[4.7.0,5.0.0)",
  org.knime.python3.types;bundle-version="[4.7.0,5.0.0)";resolution:=optional
 Bundle-Vendor: NIBR

--- a/org.rdkit.knime.types/build.properties
+++ b/org.rdkit.knime.types/build.properties
@@ -5,7 +5,8 @@ bin.includes = META-INF/,\
                plugin.xml,\
                python/,\
                schema/,\
-               rdkit-chem.jar
+               rdkit-chem.jar,\
+               python3/
 jars.extra.classpath = lib/org.RDKit.jar, lib/org.RDKitDoc.jar
 jars.compile.order = rdkit-chem.jar
 source.rdkit-chem.jar = rdkit-chemsrc/

--- a/org.rdkit.knime.types/plugin.xml
+++ b/org.rdkit.knime.types/plugin.xml
@@ -14,6 +14,16 @@
    	   	  		cellClass="org.rdkit.knime.types.RDKitAdapterCell" 
    	   	  		serializerClass="org.rdkit.knime.types.RDKitAdapterCell$RDKitAdapterCellSerializer">
           </serializer>
+          <ValueFactory
+                deprecated="false"
+                cellClass="org.rdkit.knime.types.RDKitMolCell2"
+                valueFactoryClass="org.rdkit.knime.types.RDKitMolCellValueFactory">
+          </ValueFactory>
+          <ValueFactory
+                deprecated="false"
+                cellClass="org.rdkit.knime.types.RDKitAdapterCell"
+                valueFactoryClass="org.rdkit.knime.types.RDKitAdapterCellValueFactory">
+          </ValueFactory>
       </DataType>
    </extension>
    
@@ -23,6 +33,11 @@
                 cellClass="org.rdkit.knime.types.RDKitReactionCell"
                 serializerClass="org.rdkit.knime.types.RDKitReactionCell$RDKitReactionSerializer">
           </serializer>
+          <ValueFactory
+                deprecated="false"
+                cellClass="org.rdkit.knime.types.RDKitReactionCell"
+                valueFactoryClass="org.rdkit.knime.types.RDKitReactionCellValueFactory">
+          </ValueFactory>
    	   </DataType>
    </extension>
    
@@ -145,5 +160,56 @@
             python-serializer="python/RDKitLongSparseIntVectSerializer.py"
             java-deserializer-factory="org.rdkit.knime.types.RDKitCountBasedFingerprintDeserializer$Factory">
       	</type>   
+   </extension>
+   <extension
+         point="org.knime.python3.types.PythonValueFactory">
+      <Module
+            modulePath="python3" moduleName="knime.types.ext.rdkit">
+         <PythonValueFactory
+               PythonClassName="RDKitMolValueFactory"
+               ValueFactory="org.rdkit.knime.types.RDKitMolCellValueFactory"
+               ValueTypeName="rdkit.Chem.rdchem.Mol">
+         </PythonValueFactory>
+         <PythonValueFactory
+               PythonClassName="RDKitMolAdapterValueFactory"
+               ValueFactory="org.rdkit.knime.types.RDKitAdapterCellValueFactory"
+               ValueTypeName="rdkit.Chem.rdchem.Mol">
+         </PythonValueFactory>
+         <PythonValueFactory
+               PythonClassName="RDKitReactionValueFactory"
+               ValueFactory="org.rdkit.knime.types.RDKitReactionCellValueFactory"
+               ValueTypeName="rdkit.Chem.rdChemReactions.ChemicalReaction">
+         </PythonValueFactory>
+         <PythonValueFactory
+               PythonClassName="RDKitFingerprintValueFactory"
+               ValueFactory="org.knime.core.data.v2.value.DenseBitVectorValueFactory"
+               ValueTypeName="rdkit.DataStructs.cDataStructs.ExplicitBitVect"
+               isDefaultPythonRepresentation="false">
+         </PythonValueFactory>
+         <PythonValueFactory
+               PythonClassName="RDKitCountFingerprintValueFactoryUInt"
+               ValueFactory="org.knime.core.data.v2.value.DenseByteVectorValueFactory"
+               ValueTypeName="rdkit.DataStructs.cDataStructs.UIntSparseIntVect"
+               isDefaultPythonRepresentation="false">
+         </PythonValueFactory>
+         <PythonValueFactory
+               PythonClassName="RDKitCountFingerprintValueFactoryInt"
+               ValueFactory="org.knime.core.data.v2.value.DenseByteVectorValueFactory"
+               ValueTypeName="rdkit.DataStructs.cDataStructs.IntSparseIntVect"
+               isDefaultPythonRepresentation="false">
+         </PythonValueFactory>
+         <PythonValueFactory
+               PythonClassName="RDKitCountFingerprintValueFactoryULong"
+               ValueFactory="org.knime.core.data.v2.value.DenseByteVectorValueFactory"
+               ValueTypeName="rdkit.DataStructs.cDataStructs.ULongSparseIntVect"
+               isDefaultPythonRepresentation="false">
+         </PythonValueFactory>
+         <PythonValueFactory
+               PythonClassName="RDKitCountFingerprintValueFactoryLong"
+               ValueFactory="org.knime.core.data.v2.value.DenseByteVectorValueFactory"
+               ValueTypeName="rdkit.DataStructs.cDataStructs.LongSparseIntVect"
+               isDefaultPythonRepresentation="false">
+         </PythonValueFactory>
+      </Module>
    </extension>   
    </plugin>

--- a/org.rdkit.knime.types/python/RDKitIntSparseIntVectSerializer.py
+++ b/org.rdkit.knime.types/python/RDKitIntSparseIntVectSerializer.py
@@ -1,2 +1,11 @@
 def serialize(object_value):
-	return str({"length":object_value.GetLength(),"bits":object_value.GetNonzeroElements()})
+    s = str(
+        {"length": object_value.GetLength(), "bits": object_value.GetNonzeroElements()}
+    )
+
+    import sys
+
+    if sys.version_info.major > 2:
+        s = s.encode()
+
+    return s

--- a/org.rdkit.knime.types/python/RDKitLongSparseIntVectSerializer.py
+++ b/org.rdkit.knime.types/python/RDKitLongSparseIntVectSerializer.py
@@ -1,2 +1,11 @@
 def serialize(object_value):
-	return str({"length":object_value.GetLength(),"bits":object_value.GetNonzeroElements()})
+    s = str(
+        {"length": object_value.GetLength(), "bits": object_value.GetNonzeroElements()}
+    )
+
+    import sys
+
+    if sys.version_info.major > 2:
+        s = s.encode()
+
+    return s

--- a/org.rdkit.knime.types/python/RDKitUIntSparseIntVectSerializer.py
+++ b/org.rdkit.knime.types/python/RDKitUIntSparseIntVectSerializer.py
@@ -1,2 +1,11 @@
 def serialize(object_value):
-	return str({"length":object_value.GetLength(),"bits":object_value.GetNonzeroElements()})
+    s = str(
+        {"length": object_value.GetLength(), "bits": object_value.GetNonzeroElements()}
+    )
+
+    import sys
+
+    if sys.version_info.major > 2:
+        s = s.encode()
+
+    return s

--- a/org.rdkit.knime.types/python3/knime/types/ext/rdkit.py
+++ b/org.rdkit.knime.types/python3/knime/types/ext/rdkit.py
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------
+#  Copyright by KNIME AG, Zurich, Switzerland
+#  Website: http://www.knime.com; Email: contact@knime.com
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License, Version 3, as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, see <http://www.gnu.org/licenses>.
+#
+#  Additional permission under GNU GPL version 3 section 7:
+#
+#  KNIME interoperates with ECLIPSE solely via ECLIPSE's plug-in APIs.
+#  Hence, KNIME and ECLIPSE are both independent programs and are not
+#  derived from each other. Should, however, the interpretation of the
+#  GNU GPL Version 3 ("License") under any applicable laws result in
+#  KNIME and ECLIPSE being a combined program, KNIME AG herewith grants
+#  you the additional permission to use and propagate KNIME together with
+#  ECLIPSE with only the license terms in place for ECLIPSE applying to
+#  ECLIPSE and the GNU GPL Version 3 applying for KNIME, provided the
+#  license terms of ECLIPSE themselves allow for the respective use and
+#  propagation of ECLIPSE together with KNIME.
+#
+#  Additional permission relating to nodes for KNIME that extend the Node
+#  Extension (and in particular that are based on subclasses of NodeModel,
+#  NodeDialog, and NodeView) and that only interoperate with KNIME through
+#  standard APIs ("Nodes"):
+#  Nodes are deemed to be separate and independent programs and to not be
+#  covered works.  Notwithstanding anything to the contrary in the
+#  License, the License does not apply to Nodes, you are not required to
+#  license Nodes under the License, and you are granted a license to
+#  prepare and propagate Nodes, in each case even if such Nodes are
+#  propagated with or for interoperation with KNIME.  The owner of a Node
+#  may freely choose the license terms applicable to such Node, including
+#  when such Node is propagated with or for interoperation with KNIME.
+# ------------------------------------------------------------------------
+
+"""
+Defines a PythonValueFactory that determines how RDKit cells
+are read and written from/to the underlying table in Python.
+
+@author Carsten Haubold, KNIME GmbH, Konstanz, Germany
+"""
+import logging
+import knime.api.types as kt
+
+LOGGER = logging.getLogger(__name__)
+
+try:
+    # We cannot import rdkit at the top of the file because it would then be required
+    # everywhere, even if we do not use the RDKit columns or don't even
+    # have an RDKit column in the table but the type is registered.
+    # All Python environments used in KNIME would then have to provide rdkit,
+    # which we don't want.
+    from rdkit import Chem
+    from rdkit.Chem.rdChemReactions import ChemicalReaction
+    from rdkit.DataStructs.cDataStructs import (
+        ExplicitBitVect,
+        UIntSparseIntVect,
+        IntSparseIntVect,
+        ULongSparseIntVect,
+        LongSparseIntVect,
+    )
+    from rdkit.DataStructs import CreateFromBinaryText, BitVectToBinaryText
+
+except ImportError as e:
+    LOGGER.info(
+        "RDKit type support not available because 'rdkit' could not be imported", e
+    )
+
+    # we define a dummy type Chem.Mol to be used instead.
+    # Any attempt to work with this data will fail.
+    class Chem:
+        class Mol:
+            pass
+
+    class ChemicalReaction:
+        pass
+
+    class ExplicitBitVect:
+        pass
+
+    class UIntSparseIntVect:
+        pass
+
+    class IntSparseIntVect:
+        pass
+
+    class LongSparseIntVect:
+        pass
+
+    class ULongSparseIntVect:
+        pass
+
+
+class RDKitMolAdapterValueFactory(kt.PythonValueFactory):
+    def __init__(self):
+        kt.PythonValueFactory.__init__(self, Chem.Mol)
+
+    def decode(self, storage):
+        if storage is None:
+            return None
+
+        value = Chem.Mol(storage["0"])
+        return value
+
+    def encode(self, value):
+        if value is None:
+            return None
+        return {"0": value.ToBinary(), "1": None}
+
+
+class RDKitMolValueFactory(kt.PythonValueFactory):
+    def __init__(self):
+        kt.PythonValueFactory.__init__(self, Chem.Mol)
+
+    def decode(self, storage):
+        if storage is None:
+            return None
+        return Chem.Mol(storage)
+
+    def encode(self, value):
+        if value is None:
+            return None
+        return value.ToBinary()
+
+
+class RDKitReactionValueFactory(kt.PythonValueFactory):
+    def __init__(self):
+        kt.PythonValueFactory.__init__(self, ChemicalReaction)
+
+    def decode(self, storage):
+        if storage is None:
+            return None
+        return ChemicalReaction(storage)
+
+    def encode(self, value):
+        if value is None:
+            return None
+        return value.ToBinary()
+
+
+class RDKitFingerprintValueFactory(kt.PythonValueFactory):
+    def __init__(self):
+        kt.PythonValueFactory.__init__(self, ExplicitBitVect)
+
+    def decode(self, storage):
+        if storage is None:
+            return None
+
+        fp = CreateFromBinaryText(storage[8:])
+        return fp
+
+    def encode(self, value):
+        if value is None:
+            return None
+
+        length_bytes = len(value).to_bytes(length=8, byteorder="little")
+        return length_bytes + BitVectToBinaryText(value)
+
+
+class AbstractRDKitCountFingerprintValueFactory(kt.PythonValueFactory):
+    def __init__(self, dtype):
+        self._dtype = dtype
+        kt.PythonValueFactory.__init__(self, dtype)
+
+    def decode(self, storage):
+        if storage is None:
+            return None
+
+        # construct a new count fingerprint of type _dtype and fill it
+        sparse_vec = self._dtype(len(storage))
+        for i, v in enumerate(storage):
+            if v:
+                sparse_vec[i] = v
+        return sparse_vec
+
+    def encode(self, value):
+        if value is None:
+            return None
+
+        ba = bytearray(value.GetLength())
+        for idx, v in value.GetNonzeroElements().items():
+            ba[idx] = v % 256
+        return ba
+
+
+class RDKitCountFingerprintValueFactoryUInt(AbstractRDKitCountFingerprintValueFactory):
+    def __init__(self):
+        super().__init__(UIntSparseIntVect)
+
+
+class RDKitCountFingerprintValueFactoryInt(AbstractRDKitCountFingerprintValueFactory):
+    def __init__(self):
+        super().__init__(IntSparseIntVect)
+
+
+class RDKitCountFingerprintValueFactoryULong(AbstractRDKitCountFingerprintValueFactory):
+    def __init__(self):
+        super().__init__(ULongSparseIntVect)
+
+
+class RDKitCountFingerprintValueFactoryLong(AbstractRDKitCountFingerprintValueFactory):
+    def __init__(self):
+        super().__init__(LongSparseIntVect)

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitAdapterCellValueFactory.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitAdapterCellValueFactory.java
@@ -1,0 +1,126 @@
+/*
+ * ------------------------------------------------------------------------
+ *
+ *  Copyright by KNIME AG, Zurich, Switzerland
+ *  Website: http://www.knime.com; Email: contact@knime.com
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License, Version 3, as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ *  Additional permission under GNU GPL version 3 section 7:
+ *
+ *  KNIME interoperates with ECLIPSE solely via ECLIPSE's plug-in APIs.
+ *  Hence, KNIME and ECLIPSE are both independent programs and are not
+ *  derived from each other. Should, however, the interpretation of the
+ *  GNU GPL Version 3 ("License") under any applicable laws result in
+ *  KNIME and ECLIPSE being a combined program, KNIME AG herewith grants
+ *  you the additional permission to use and propagate KNIME together with
+ *  ECLIPSE with only the license terms in place for ECLIPSE applying to
+ *  ECLIPSE and the GNU GPL Version 3 applying for KNIME, provided the
+ *  license terms of ECLIPSE themselves allow for the respective use and
+ *  propagation of ECLIPSE together with KNIME.
+ *
+ *  Additional permission relating to nodes for KNIME that extend the Node
+ *  Extension (and in particular that are based on subclasses of NodeModel,
+ *  NodeDialog, and NodeView) and that only interoperate with KNIME through
+ *  standard APIs ("Nodes"):
+ *  Nodes are deemed to be separate and independent programs and to not be
+ *  covered works.  Notwithstanding anything to the contrary in the
+ *  License, the License does not apply to Nodes, you are not required to
+ *  license Nodes under the License, and you are granted a license to
+ *  prepare and propagate Nodes, in each case even if such Nodes are
+ *  propagated with or for interoperation with KNIME.  The owner of a Node
+ *  may freely choose the license terms applicable to such Node, including
+ *  when such Node is propagated with or for interoperation with KNIME.
+ * ---------------------------------------------------------------------
+ *
+ * History
+ *   Oct 7, 2020 (dietzc): created
+ */
+package org.rdkit.knime.types;
+
+import java.io.IOException;
+
+import org.knime.core.data.AdapterCell;
+import org.knime.core.data.IDataRepository;
+import org.knime.core.data.filestore.internal.IWriteFileStoreHandler;
+import org.knime.core.data.v2.ReadValue;
+import org.knime.core.data.v2.ValueFactory;
+import org.knime.core.data.v2.WriteValue;
+import org.knime.core.data.v2.value.AbstractAdapterCellValueFactory;
+import org.knime.core.node.NodeLogger;
+import org.knime.core.table.access.ReadAccess;
+import org.knime.core.table.access.StructAccess.StructReadAccess;
+import org.knime.core.table.access.StructAccess.StructWriteAccess;
+import org.knime.core.table.access.VarBinaryAccess.VarBinaryReadAccess;
+import org.knime.core.table.access.VarBinaryAccess.VarBinaryWriteAccess;
+import org.knime.core.table.access.WriteAccess;
+import org.knime.core.table.schema.DataSpec;
+import org.knime.core.table.schema.VarBinaryDataSpec;
+
+/**
+ * A {@link ValueFactory} to support {@link RDKitAdapterCell}s in the columnar
+ * backend, and to support reading and writing from Python
+ * 
+ * @author Carsten Haubold, KNIME GmbH, Konstanz, Germany
+ */
+public class RDKitAdapterCellValueFactory extends AbstractAdapterCellValueFactory {
+
+	private static final NodeLogger LOGGER = NodeLogger.getLogger(RDKitAdapterCellValueFactory.class);
+
+	@Override
+	public ReadValue createReadValue(StructReadAccess access) {
+		return new RDKitAdapterCellReadValue(access, m_dataRepository);
+	}
+
+	@Override
+	public WriteValue<?> createWriteValue(StructWriteAccess access) {
+		return new RDKitAdapterCellWriteValue(access, m_writeFileStoreHandler);
+	}
+
+	@Override
+	protected DataSpec getPrimarySpec() {
+		return VarBinaryDataSpec.INSTANCE;
+	}
+
+	private static final class RDKitAdapterCellWriteValue extends AbstractAdapterCellWriteValue<RDKitAdapterCell> {
+		private RDKitAdapterCellWriteValue(final StructWriteAccess access, final IWriteFileStoreHandler fsHandler) {
+			super(access, fsHandler);
+		}
+
+		@Override
+		protected void setPrimaryValue(final RDKitAdapterCell value, final WriteAccess writeAccess) {
+			try {
+				((VarBinaryWriteAccess) writeAccess).setByteArray(RDKitTypeSerializationUtils.serializeMolValue(value));
+			} catch (IOException e) {
+				LOGGER.error("Error when serializing RDKitMolValue", e);
+			}
+		}
+	}
+
+	private static final class RDKitAdapterCellReadValue extends AbstractAdapterCellReadValue {
+		private RDKitAdapterCellReadValue(final StructReadAccess access, final IDataRepository dataRepository) {
+			super(access, dataRepository);
+		}
+
+		@Override
+		protected AdapterCell getAdapterCell(final ReadAccess readAccess) {
+			try {
+				return (AdapterCell) (RDKitTypeSerializationUtils
+						.deserializeMolCell2(((VarBinaryReadAccess) readAccess).getByteArray()));
+			} catch (IOException e) {
+				LOGGER.error("Error when deserializing RDKitMolValue", e);
+				return null;
+			}
+		}
+	}
+}

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitMolCellValueFactory.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitMolCellValueFactory.java
@@ -1,0 +1,154 @@
+/*
+ * ------------------------------------------------------------------------
+ *
+ *  Copyright by KNIME AG, Zurich, Switzerland
+ *  Website: http://www.knime.com; Email: contact@knime.com
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License, Version 3, as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ *  Additional permission under GNU GPL version 3 section 7:
+ *
+ *  KNIME interoperates with ECLIPSE solely via ECLIPSE's plug-in APIs.
+ *  Hence, KNIME and ECLIPSE are both independent programs and are not
+ *  derived from each other. Should, however, the interpretation of the
+ *  GNU GPL Version 3 ("License") under any applicable laws result in
+ *  KNIME and ECLIPSE being a combined program, KNIME AG herewith grants
+ *  you the additional permission to use and propagate KNIME together with
+ *  ECLIPSE with only the license terms in place for ECLIPSE applying to
+ *  ECLIPSE and the GNU GPL Version 3 applying for KNIME, provided the
+ *  license terms of ECLIPSE themselves allow for the respective use and
+ *  propagation of ECLIPSE together with KNIME.
+ *
+ *  Additional permission relating to nodes for KNIME that extend the Node
+ *  Extension (and in particular that are based on subclasses of NodeModel,
+ *  NodeDialog, and NodeView) and that only interoperate with KNIME through
+ *  standard APIs ("Nodes"):
+ *  Nodes are deemed to be separate and independent programs and to not be
+ *  covered works.  Notwithstanding anything to the contrary in the
+ *  License, the License does not apply to Nodes, you are not required to
+ *  license Nodes under the License, and you are granted a license to
+ *  prepare and propagate Nodes, in each case even if such Nodes are
+ *  propagated with or for interoperation with KNIME.  The owner of a Node
+ *  may freely choose the license terms applicable to such Node, including
+ *  when such Node is propagated with or for interoperation with KNIME.
+ * ---------------------------------------------------------------------
+ *
+ * History
+ *   Oct 7, 2020 (dietzc): created
+ */
+package org.rdkit.knime.types;
+
+import java.io.IOException;
+
+import org.RDKit.ROMol;
+import org.knime.core.data.DataCell;
+import org.knime.core.data.v2.ReadValue;
+import org.knime.core.data.v2.ValueFactory;
+import org.knime.core.data.v2.WriteValue;
+import org.knime.core.node.NodeLogger;
+import org.knime.core.table.access.VarBinaryAccess.VarBinaryReadAccess;
+import org.knime.core.table.access.VarBinaryAccess.VarBinaryWriteAccess;
+import org.knime.core.table.schema.DataSpec;
+import org.knime.core.table.schema.VarBinaryDataSpec;
+
+/**
+ * The {@link ValueFactory} specifies how {@link RDKitMolValue}s are serialized
+ * in KNIME's Columnar Backend, which is needed also for communication with the
+ * Python (Labs) Scripting node and pure-Python nodes in KNIME.
+ * 
+ * Serialization into a binary blob works by using the
+ * {@link RDKitMolSerializer}.
+ * 
+ * @author Carsten Haubold, KNIME GmbH, Konstanz, Germany
+ */
+public class RDKitMolCellValueFactory implements ValueFactory<VarBinaryReadAccess, VarBinaryWriteAccess> { // NOSONAR:
+																											// cannot be
+																											// removed
+
+	private static final NodeLogger LOGGER = NodeLogger.getLogger(RDKitMolCellValueFactory.class);
+	/**
+	 * Stateless instance of this {@link RDKitMolCellValueFactory}.
+	 */
+	public static final RDKitMolCellValueFactory INSTANCE = new RDKitMolCellValueFactory();
+
+	@Override
+	public DataSpec getSpec() {
+		return VarBinaryDataSpec.INSTANCE;
+	}
+
+	private static final class RDKitMolCellWriteValue implements WriteValue<RDKitMolValue> {
+		private final VarBinaryWriteAccess m_access;
+
+		private RDKitMolCellWriteValue(final VarBinaryWriteAccess access) {
+			m_access = access;
+		}
+
+		public void setValue(final RDKitMolValue value) {
+			try {
+				m_access.setByteArray(RDKitTypeSerializationUtils.serializeMolValue(value));
+			} catch (IOException e) {
+				LOGGER.error("Error when serializing RDKitMolValue", e);
+			}
+		}
+	}
+
+	private static final class RDKitMolCellReadValue implements ReadValue, RDKitMolValue {
+		private final VarBinaryReadAccess m_access;
+
+		private RDKitMolCellReadValue(final VarBinaryReadAccess access) {
+			m_access = access;
+		}
+
+		@Override
+		public DataCell getDataCell() {
+			try {
+				return RDKitTypeSerializationUtils.deserializeMolCell2(m_access.getByteArray());
+			} catch (IOException e) {
+				LOGGER.error("Error when deserializing RDKitMolValue", e);
+				return null;
+			}
+		}
+
+		@Override
+		public ROMol readMoleculeValue() {
+			// Note that these methods of the RDKitMolValue interface currently always
+			// cause a deserialization to happen. This is not very efficient, but necessary
+			// as the ReadValue is re-used when iterating over the rows of a KNIME table.
+			// An API to know whether a new value needs to be read is being developed.
+			// However, this is not a pressing issue yet as the ReadValues are not used
+			// directly yet but are passed to the BufferedDataTable using a single call to
+			// getDataCell().
+			return ((RDKitMolValue) getDataCell()).readMoleculeValue();
+		}
+
+		@Override
+		public String getSmilesValue() {
+			return ((RDKitMolValue) getDataCell()).getSmilesValue();
+		}
+
+		@Override
+		public boolean isSmilesCanonical() {
+			return ((RDKitMolValue) getDataCell()).isSmilesCanonical();
+		}
+	}
+
+	@Override
+	public ReadValue createReadValue(VarBinaryReadAccess access) {
+		return new RDKitMolCellReadValue(access);
+	}
+
+	@Override
+	public WriteValue<?> createWriteValue(VarBinaryWriteAccess access) {
+		return new RDKitMolCellWriteValue(access);
+	}
+}

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitMolDeserializer.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitMolDeserializer.java
@@ -2,11 +2,8 @@ package org.rdkit.knime.types;
 
 import java.io.IOException;
 
-import org.RDKit.ROMol;
 import org.knime.core.data.DataCell;
-import org.knime.core.data.DataType;
 import org.knime.core.data.filestore.FileStoreFactory;
-import org.knime.core.node.NodeLogger;
 import org.knime.python.typeextension.Deserializer;
 import org.knime.python.typeextension.DeserializerFactory;
 
@@ -39,51 +36,12 @@ public class RDKitMolDeserializer implements Deserializer {
 	}
 
 	//
-	// Constants
-	//
-
-	/** The logging instance. */
-	private static final NodeLogger LOGGER = NodeLogger.getLogger(RDKitMolDeserializer.class);
-
-	//
 	// Public Methods
 	//
 
 	@Override
 	public DataCell deserialize(final byte[] bytes, final FileStoreFactory fileStoreFactory) throws IOException {
-		DataCell cell;
-
-		// Generate missing cell, if input is unavailable
-		if (bytes == null || bytes.length == 0) {
-			cell = DataType.getMissingCell();
-		}
-
-		// Generate an RDKit Mol Cell with canonicalized SMILES attached
-		else {
-			ROMol mol = null;
-			try {
-				mol = RDKitMolCell2.toROMol(bytes);
-				cell = RDKitMolCellFactory.createRDKitAdapterCell(mol, null);
-			}
-			catch (final Exception exc) {
-				LOGGER.debug(exc);
-
-				// In case of an error throw an IOException
-				String strMsg = exc.getMessage();
-				if (strMsg == null || strMsg.trim().isEmpty()) {
-					strMsg = "Unknown error";
-				}
-				throw new IOException("Unable to interpret RDKit Molecule: " + strMsg);
-
-			}
-			finally {
-				if (mol != null) {
-					mol.delete();
-				}
-			}
-		}
-
-		return cell;
+		return RDKitTypeSerializationUtils.deserializeMolCell2(bytes);
 	}
 
 }

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitMolSerializer.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitMolSerializer.java
@@ -2,7 +2,6 @@ package org.rdkit.knime.types;
 
 import java.io.IOException;
 
-import org.RDKit.ROMol;
 import org.knime.python.typeextension.Serializer;
 import org.knime.python.typeextension.SerializerFactory;
 
@@ -48,30 +47,6 @@ public class RDKitMolSerializer implements Serializer<RDKitMolValue> {
 	 */
 	@Override
 	public byte[] serialize(final RDKitMolValue value) throws IOException {
-		byte[] arrBinaryMolecule = null;
-
-		if (value != null) {
-			// Shortcut for the normal case that we have a normal RDKit Mol Cell
-			if (value instanceof RDKitMolCell2) {
-				arrBinaryMolecule = ((RDKitMolCell2)value).getBinaryValue();
-			}
-
-			// Longer way if we have a different implementation (e.g. Adapter Cell), which is slower but always works
-			else {
-				ROMol mol = null;
-
-				try {
-					mol = value.readMoleculeValue();
-					arrBinaryMolecule = RDKitMolCell2.toByteArray(mol);
-				}
-				finally {
-					if (mol != null) {
-						mol.delete();
-					}
-				}
-			}
-		}
-
-		return arrBinaryMolecule;
+		return RDKitTypeSerializationUtils.serializeMolValue(value);
 	}
 }

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitReactionCellValueFactory.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitReactionCellValueFactory.java
@@ -1,0 +1,152 @@
+/*
+ * ------------------------------------------------------------------------
+ *
+ *  Copyright by KNIME AG, Zurich, Switzerland
+ *  Website: http://www.knime.com; Email: contact@knime.com
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License, Version 3, as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ *  Additional permission under GNU GPL version 3 section 7:
+ *
+ *  KNIME interoperates with ECLIPSE solely via ECLIPSE's plug-in APIs.
+ *  Hence, KNIME and ECLIPSE are both independent programs and are not
+ *  derived from each other. Should, however, the interpretation of the
+ *  GNU GPL Version 3 ("License") under any applicable laws result in
+ *  KNIME and ECLIPSE being a combined program, KNIME AG herewith grants
+ *  you the additional permission to use and propagate KNIME together with
+ *  ECLIPSE with only the license terms in place for ECLIPSE applying to
+ *  ECLIPSE and the GNU GPL Version 3 applying for KNIME, provided the
+ *  license terms of ECLIPSE themselves allow for the respective use and
+ *  propagation of ECLIPSE together with KNIME.
+ *
+ *  Additional permission relating to nodes for KNIME that extend the Node
+ *  Extension (and in particular that are based on subclasses of NodeModel,
+ *  NodeDialog, and NodeView) and that only interoperate with KNIME through
+ *  standard APIs ("Nodes"):
+ *  Nodes are deemed to be separate and independent programs and to not be
+ *  covered works.  Notwithstanding anything to the contrary in the
+ *  License, the License does not apply to Nodes, you are not required to
+ *  license Nodes under the License, and you are granted a license to
+ *  prepare and propagate Nodes, in each case even if such Nodes are
+ *  propagated with or for interoperation with KNIME.  The owner of a Node
+ *  may freely choose the license terms applicable to such Node, including
+ *  when such Node is propagated with or for interoperation with KNIME.
+ * ---------------------------------------------------------------------
+ *
+ * History
+ *   Oct 7, 2020 (dietzc): created
+ */
+package org.rdkit.knime.types;
+
+import java.io.IOException;
+
+import org.RDKit.ChemicalReaction;
+import org.knime.core.data.DataCell;
+import org.knime.core.data.v2.ReadValue;
+import org.knime.core.data.v2.ValueFactory;
+import org.knime.core.data.v2.WriteValue;
+import org.knime.core.node.NodeLogger;
+import org.knime.core.table.access.VarBinaryAccess.VarBinaryReadAccess;
+import org.knime.core.table.access.VarBinaryAccess.VarBinaryWriteAccess;
+import org.knime.core.table.schema.DataSpec;
+import org.knime.core.table.schema.VarBinaryDataSpec;
+
+/**
+ * The {@link ValueFactory} specifies how a {@link RDKitReactionValue} is
+ * serialized in KNIME's Columnar Backend, which is needed also for
+ * communication with the Python (Labs) Scripting node and pure-Python nodes in
+ * KNIME.
+ * 
+ * Serialization into a binary blob works by using the
+ * {@link RDKitReactionSerializer}.
+ * 
+ * @author Carsten Haubold, KNIME GmbH, Konstanz, Germany
+ */
+public class RDKitReactionCellValueFactory implements ValueFactory<VarBinaryReadAccess, VarBinaryWriteAccess> { // NOSONAR:
+																												// cannot
+																												// be
+																												// removed
+
+	private static final NodeLogger LOGGER = NodeLogger.getLogger(RDKitReactionCellValueFactory.class);
+
+	/**
+	 * Stateless instance of this {@link RDKitReactionCellValueFactory}.
+	 */
+	public static final RDKitReactionCellValueFactory INSTANCE = new RDKitReactionCellValueFactory();
+
+	@Override
+	public DataSpec getSpec() {
+		return VarBinaryDataSpec.INSTANCE;
+	}
+
+	private static final class RDKitReactionCellWriteValue implements WriteValue<RDKitReactionValue> {
+		private final VarBinaryWriteAccess m_access;
+
+		private RDKitReactionCellWriteValue(final VarBinaryWriteAccess access) {
+			m_access = access;
+		}
+
+		public void setValue(final RDKitReactionValue value) {
+			try {
+				m_access.setByteArray(RDKitTypeSerializationUtils.serializeReactionValue(value));
+			} catch (IOException e) {
+				LOGGER.error("Error when serializing RDKitReactionValue", e);
+			}
+		}
+	}
+
+	private static final class RDKitReactionCellReadValue implements ReadValue, RDKitReactionValue {
+		private final VarBinaryReadAccess m_access;
+
+		private RDKitReactionCellReadValue(final VarBinaryReadAccess access) {
+			m_access = access;
+		}
+
+		@Override
+		public DataCell getDataCell() {
+			try {
+				return RDKitTypeSerializationUtils.deserializeReactionCell(m_access.getByteArray());
+			} catch (IOException e) {
+				LOGGER.error("Error when deserializing RDKitMolValue", e);
+				return null;
+			}
+		}
+
+		@Override
+		public ChemicalReaction getReactionValue() {
+			// Note that these methods of the RDKitMolValue interface currently always
+			// cause a deserialization to happen. This is not very efficient, but necessary
+			// as the ReadValue is re-used when iterating over the rows of a KNIME table.
+			// An API to know whether a new value needs to be read is being developed.
+			// However, this is not a pressing issue yet as the ReadValues are not used
+			// directly yet but are passed to the BufferedDataTable using a single call to
+			// getDataCell().
+			return ((RDKitReactionValue) getDataCell()).getReactionValue();
+		}
+
+		@Override
+		public String getSmilesValue() {
+			return ((RDKitReactionValue) getDataCell()).getSmilesValue();
+		}
+	}
+
+	@Override
+	public ReadValue createReadValue(VarBinaryReadAccess access) {
+		return new RDKitReactionCellReadValue(access);
+	}
+
+	@Override
+	public WriteValue<RDKitReactionValue> createWriteValue(VarBinaryWriteAccess access) {
+		return new RDKitReactionCellWriteValue(access);
+	}
+}

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitReactionDeserializer.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitReactionDeserializer.java
@@ -2,11 +2,8 @@ package org.rdkit.knime.types;
 
 import java.io.IOException;
 
-import org.RDKit.ChemicalReaction;
 import org.knime.core.data.DataCell;
-import org.knime.core.data.DataType;
 import org.knime.core.data.filestore.FileStoreFactory;
-import org.knime.core.node.NodeLogger;
 import org.knime.python.typeextension.Deserializer;
 import org.knime.python.typeextension.DeserializerFactory;
 
@@ -39,44 +36,12 @@ public class RDKitReactionDeserializer implements Deserializer {
 	}
 
 	//
-	// Constants
-	//
-
-	/** The logging instance. */
-	private static final NodeLogger LOGGER = NodeLogger.getLogger(RDKitReactionDeserializer.class);
-
-	//
 	// Public Methods
 	//
 
 	@Override
 	public DataCell deserialize(final byte[] bytes, final FileStoreFactory fileStoreFactory) throws IOException {
-		DataCell cell;
-
-		// Generate missing cell, if input is unavailable
-		if (bytes == null || bytes.length == 0) {
-			cell = DataType.getMissingCell();
-		}
-
-		// Generate an RDKit Reaction Cell
-		else {
-			try {
-				final ChemicalReaction reaction = RDKitReactionCell.toChemicalReaction(bytes);
-				cell = new RDKitReactionCell(reaction);
-			}
-			catch (final Exception exc) {
-				LOGGER.debug(exc);
-				// In case of an error throw an IOException
-				String strMsg = exc.getMessage();
-				if (strMsg == null || strMsg.trim().isEmpty()) {
-					strMsg = "Unknown error";
-				}
-				throw new IOException("Unable to interpret RDKit Reaction: " + strMsg);
-			}
-			// Note: Do not delete the reaction object here, because it is used in the cell
-		}
-
-		return cell;
+		return RDKitTypeSerializationUtils.deserializeReactionCell(bytes);
 	}
 
 }

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitReactionSerializer.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitReactionSerializer.java
@@ -2,7 +2,6 @@ package org.rdkit.knime.types;
 
 import java.io.IOException;
 
-import org.RDKit.ChemicalReaction;
 import org.knime.python.typeextension.Serializer;
 import org.knime.python.typeextension.SerializerFactory;
 
@@ -48,14 +47,6 @@ public class RDKitReactionSerializer implements Serializer<RDKitReactionValue> {
 	 */
 	@Override
 	public byte[] serialize(final RDKitReactionValue value) throws IOException {
-		byte[] arrBinaryReaction = null;
-
-		if (value != null) {
-			final ChemicalReaction reaction = value.getReactionValue();
-			arrBinaryReaction = RDKitReactionCell.toByteArray(reaction);
-			// Note: Do not delete the reaction object here, because it is a reference to real cell content
-		}
-
-		return arrBinaryReaction;
+		return RDKitTypeSerializationUtils.serializeReactionValue(value);
 	}
 }

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitTypeSerializationUtils.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitTypeSerializationUtils.java
@@ -1,0 +1,134 @@
+package org.rdkit.knime.types;
+
+import java.io.IOException;
+
+import org.RDKit.ChemicalReaction;
+import org.RDKit.ROMol;
+import org.knime.core.data.DataCell;
+import org.knime.core.data.DataType;
+import org.knime.core.node.NodeLogger;
+
+/**
+ * Serialization methods used by KNIME for the old Python integrations (org.knime.python and org.knime.python2),
+ * as well as the Columnar Backend and the current Python integration (org.knime.python3).
+ * 
+ * The methods live in a separate class because the "old" and "current" Python integrations are both optional and
+ * should not depend on each other, so the shared functionality must live outside of both.
+ * 
+ * @author Carsten Haubold, KNIME GmbH, Konstanz, Germany
+ */
+public class RDKitTypeSerializationUtils { 
+	//
+	// Constants
+	//
+	private static final NodeLogger LOGGER = NodeLogger.getLogger(RDKitTypeSerializationUtils.class);
+	
+	
+	//
+	// Public Methods
+	//
+	public static DataCell deserializeMolCell2(final byte[] bytes) throws IOException {
+		DataCell cell;
+
+		// Generate missing cell, if input is unavailable
+		if (bytes == null || bytes.length == 0) {
+			cell = DataType.getMissingCell();
+		}
+
+		// Generate an RDKit Mol Cell with canonicalized SMILES attached
+		else {
+			ROMol mol = null;
+			try {
+				mol = RDKitMolCell2.toROMol(bytes);
+				cell = RDKitMolCellFactory.createRDKitAdapterCell(mol, null);
+			}
+			catch (final Exception exc) {
+				LOGGER.debug(exc);
+
+				// In case of an error throw an IOException
+				String strMsg = exc.getMessage();
+				if (strMsg == null || strMsg.trim().isEmpty()) {
+					strMsg = "Unknown error";
+				}
+				throw new IOException("Unable to interpret RDKit Molecule: " + strMsg);
+
+			}
+			finally {
+				if (mol != null) {
+					mol.delete();
+				}
+			}
+		}
+
+		return cell;
+	}
+	
+	public static byte[] serializeMolValue(RDKitMolValue value) throws IOException {
+		byte[] arrBinaryMolecule = null;
+
+		if (value != null) {
+			// Shortcut for the normal case that we have a normal RDKit Mol Cell
+			if (value instanceof RDKitMolCell2) {
+				arrBinaryMolecule = ((RDKitMolCell2)value).getBinaryValue();
+			}
+
+			// Longer way if we have a different implementation (e.g. Adapter Cell), which is slower but always works
+			else {
+				ROMol mol = null;
+
+				try {
+					mol = value.readMoleculeValue();
+					arrBinaryMolecule = RDKitMolCell2.toByteArray(mol);
+				}
+				finally {
+					if (mol != null) {
+						mol.delete();
+					}
+				}
+			}
+		}
+
+		return arrBinaryMolecule;
+	}
+	
+	public static byte[] serializeReactionValue(final RDKitReactionValue value) throws IOException {
+		byte[] arrBinaryReaction = null;
+
+		if (value != null) {
+			final ChemicalReaction reaction = value.getReactionValue();
+			arrBinaryReaction = RDKitReactionCell.toByteArray(reaction);
+			// Note: Do not delete the reaction object here, because it is a reference to real cell content
+		}
+
+		return arrBinaryReaction;
+	}
+	
+	public static DataCell deserializeReactionCell(final byte[] bytes) throws IOException {
+		DataCell cell;
+
+		// Generate missing cell, if input is unavailable
+		if (bytes == null || bytes.length == 0) {
+			cell = DataType.getMissingCell();
+		}
+
+		// Generate an RDKit Reaction Cell
+		else {
+			try {
+				final ChemicalReaction reaction = RDKitReactionCell.toChemicalReaction(bytes);
+				cell = new RDKitReactionCell(reaction);
+			}
+			catch (final Exception exc) {
+				LOGGER.debug(exc);
+				// In case of an error throw an IOException
+				String strMsg = exc.getMessage();
+				if (strMsg == null || strMsg.trim().isEmpty()) {
+					strMsg = "Unknown error";
+				}
+				throw new IOException("Unable to interpret RDKit Reaction: " + strMsg);
+			}
+			// Note: Do not delete the reaction object here, because it is used in the cell
+		}
+
+		return cell;
+	}
+}

--- a/org.rdkit.knime.update/BUILD RDKIT FEATURE FOR NIBR.launch
+++ b/org.rdkit.knime.update/BUILD RDKIT FEATURE FOR NIBR.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
     <booleanAttribute key="M2_DEBUG_OUTPUT" value="true"/>
-    <stringAttribute key="M2_GOALS" value="-U clean verify -Dknime.version=4.6 -Dupdate.site=http://chbs-knime-app.dev.nibr.novartis.net/4.6/update/mirror -Dqualifier.prefix=vnibr"/>
+    <stringAttribute key="M2_GOALS" value="-U clean verify -Dqualifier.prefix=vnibr"/>
     <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
     <booleanAttribute key="M2_OFFLINE" value="false"/>
     <stringAttribute key="M2_PROFILES" value=""/>

--- a/org.rdkit.knime.wizards.feature/feature.xml
+++ b/org.rdkit.knime.wizards.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.rdkit.knime.wizards.feature"
       label="RDKit Nodes Creation Wizards Feature"
-      version="4.6.1.qualifier"
+      version="4.7.0.qualifier"
       provider-name="NIBR"
       plugin="org.rdkit.knime.wizards">
 

--- a/org.rdkit.knime.wizards.samples/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.wizards.samples/META-INF/MANIFEST.MF
@@ -3,13 +3,13 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Nodes Creation Wizards Samples
 Bundle-SymbolicName: org.rdkit.knime.wizards.samples;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.wizards.samples
-Bundle-Version: 4.6.1.qualifier
+Bundle-Version: 4.7.0.qualifier
 Bundle-Activator: org.rdkit.knime.wizards.samples.Activator
 Bundle-Vendor: NIBR
-Require-Bundle: org.knime.base;bundle-version="[4.6.0,5.0.0)";resolution:=optional,
- org.knime.chem.types;bundle-version="[4.6.0,5.0.0)";resolution:=optional,
- org.rdkit.knime.nodes;bundle-version="[4.6.1,5.0.0)";resolution:=optional,
- org.rdkit.knime.types;bundle-version="[4.6.1,5.0.0)";resolution:=optional,
+Require-Bundle: org.knime.base;bundle-version="[4.7.0,5.0.0)";resolution:=optional,
+ org.knime.chem.types;bundle-version="[4.7.0,5.0.0)";resolution:=optional,
+ org.rdkit.knime.nodes;bundle-version="[4.7.0,5.0.0)";resolution:=optional,
+ org.rdkit.knime.types;bundle-version="[4.7.0,5.0.0)";resolution:=optional,
  org.eclipse.ui;bundle-version="[3.119.0,4.0.0)";resolution:=optional,
  org.eclipse.core.runtime;bundle-version="[3.20.0,4.0.0)";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.rdkit.knime.wizards/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.wizards/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RDKit Nodes Creation Wizards
 Bundle-SymbolicName: org.rdkit.knime.wizards;singleton:=true
 Automatic-Module-Name: org.rdkit.knime.wizards
-Bundle-Version: 4.6.1.qualifier
+Bundle-Version: 4.7.0.qualifier
 Bundle-Activator: org.rdkit.knime.wizards.RDKitNodesWizardsPlugin
 Bundle-Vendor: NIBR
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.20.0,4.0.0)",

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,9 @@
 		<module>org.rdkit.knime.testing.feature</module>
 		<module>org.rdkit.knime.types</module>
 		<module>org.rdkit.knime.bin.linux.x86_64</module>
-		<module>org.rdkit.knime.bin.macosx.x86_64</module>
 		<module>org.rdkit.knime.bin.win32.x86_64</module>
+		<module>org.rdkit.knime.bin.macosx.x86_64</module>
+		<module>org.rdkit.knime.bin.macosx.aarch64</module>
 		<module>org.rdkit.knime.wizards</module>
 		<module>org.rdkit.knime.wizards.feature</module>
 		<module>org.rdkit.knime.wizards.samples</module>
@@ -169,6 +170,7 @@
 						<plugin id="org.rdkit.knime.bin.linux.x86_64" />
 						<plugin id="org.rdkit.knime.bin.win32.x86_64" />
 						<plugin id="org.rdkit.knime.bin.macosx.x86_64" />
+						<plugin id="org.rdkit.knime.bin.macosx.aarch64" />
 					</excludes>
 				</configuration>
 			</plugin>
@@ -223,6 +225,11 @@
 							<os>macosx</os>
 							<ws>cocoa</ws>
 							<arch>x86_64</arch>
+						</environment>
+						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
+							<arch>aarch64</arch>
 						</environment>
 					</environments>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,9 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<revision>4.6.1</revision>
+		<revision>4.7.0</revision>
 		<changelist>-SNAPSHOT</changelist>
-		<knime.version>4.6</knime.version>
+		<knime.version>4.7</knime.version>
 		<tycho.version>2.7.3</tycho.version>
 		<tycho.extras.version>${tycho.version}</tycho.extras.version>
 		<qualifier.prefix>v</qualifier.prefix>
@@ -51,6 +51,19 @@
 	<build>
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-compiler-plugin</artifactId>
+					<version>${tycho.version}</version>
+					<configuration>
+						<compilerArgs>
+							<arg>--module-path</arg>
+							<arg>${java.home}/jmods</arg>
+							<arg>--add-modules</arg>
+							<arg>jdk.xml.dom</arg>
+						</compilerArgs>
+					</configuration>
+				</plugin>
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>tycho-maven-plugin</artifactId>


### PR DESCRIPTION
RDKit Feature Version bump to 4.7.0
Rebased with KNIME 4.6 changes in current master (RDKit version 4.6.1)
KNIME 4.7 related changes
Added KNIME 4.7 target platform setup
Python3 support for writing Python nodes with RDKit functionality (done by @chaubold)
Finalized Mac aarch64 support

The merge of this PR to master will be the new nightly build and will be immediately released as official 4.7.0 version to replace(!) Release_KNIME4.7 branch (because the history was rearranged)