### PR TITLE
KNIME-1499 Bugfix for RDKit on KNIME executor

### DIFF
--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/RDKitTypesPluginActivator.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/RDKitTypesPluginActivator.java
@@ -203,8 +203,6 @@ public class RDKitTypesPluginActivator extends AbstractUIPlugin {
 						}
 					}
 				});
-		RDKitDepicterPreferencePage.clearConfigCacheAndResetFailure();
-		RDKitTypesPreferencePage.updateConfigCache();
 	}
 
 	/**

--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/preferences/RDKitDepicterPreferencePage.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/preferences/RDKitDepicterPreferencePage.java
@@ -261,7 +261,7 @@ public class RDKitDepicterPreferencePage extends FieldEditorPreferencePage imple
 				+ "highlight=moldrawoptions#rdkit.Chem.Draw.rdMolDraw2D.MolDrawOptions\">Click here</a>"
 				+ " for RDKit 2D Depiction options (RDKit API docs).");
 		addField(linkDocs);
-		
+
 		m_editorConfigFile = new StringFieldEditor(PREF_KEY_CONFIG_FILE, "File or URL with JSON Configuration",
 				getFieldEditorParent());
 		addField(m_editorConfigFile);
@@ -445,14 +445,13 @@ public class RDKitDepicterPreferencePage extends FieldEditorPreferencePage imple
 					prefStore.setDefault(PREF_KEY_CONFIG_JSON, "");
 					prefStore.setDefault(PREF_KEY_RETRY_INTERVAL, DEFAULT_RETRY_INTERVAL);
 					prefStore.setDefault(PREF_KEY_NORMALIZE_DEPICTIONS, DEFAULT_NORMALIZE_DEPICTIONS);
+					RDKitDepicterPreferencePage.clearConfigCacheAndResetFailure();
 				}
 			} 
 			catch (final Exception exc) {
 				LOGGER.error(
 						"Default values could not be set for the RDKit 2D Depiction preferences. Plug-In or Preference Store not found.", exc);
 			}
-			
-			RDKitDepicterPreferencePage.clearConfigCacheAndResetFailure();
 		}
 	}
 


### PR DESCRIPTION
This PR is a hotfix and addresses a bug I introduced in the last change, which affects KNIME executor (server-side) RDKit execution badly. Basically, it prevents the RDKit feature to initialize properly when running in headless mode. KNIME AP was not affected.

I will deploy this first in NIBR after approval (where it was tested already in Linux KNIME API and executor), then I will cherry-pick this change and push it in all Release_KNIME4.x branches (2..7) as well as master.