### PR TITLE
KNIME-1692: Bugfix - SMILES RDKit depiction may display inverted stereochemistry

### DIFF
--- a/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitMolValueRenderer.java
+++ b/org.rdkit.knime.types/rdkit-chemsrc/org/rdkit/knime/types/RDKitMolValueRenderer.java
@@ -607,6 +607,13 @@ implements SvgProvider {
 			// orienting the main molecule axis along the X axis when bNormalize is true.
 			if (mol.getNumConformers() > 0) {
 				mol.normalizeDepiction(-1, bNormalize ? 1 : 0, bUseCoordGen ? -1.0 : 1.0);
+				if (bNormalize) {
+					// canonicalization may flip the molecule around the Z axis,
+					// so we recompute bond wedging to make sure the stereochemistry
+					// is depicted correctly (KNIME-1692)
+					mol.ClearSingleBondDirFlags();
+					mol.WedgeMolBonds(mol.getConformer());
+				}
 			}
 		}
 


### PR DESCRIPTION
We found that when rendering molecules and normalize them (based on our preference) we carry out a coordinate transformation that yields a flip around the Z axis, which may lead to incorrect stereochemistry depiction. So we recompute bond wedging to make sure the stereochemistry is depicted correctly.

In the most general case, after calling normalizeDepiction, the prepareMolBeforeDrawing MolDraw2D option will already take care of recomputing bond wedging information. In our case, this does not happen because we have specific requirements why we prefer to call prepareMolForDrawing ourselves, specifically because we want to avoid an exception in case it fails to kekulize, and still draw a non-kekulized structure. This requires that we make the necessary wedging calls ourselves.

Thanks to @ptosco for fixing! We intend to merge this with master, and cherry-pick then from there also into nightly-pre4.7 (which is used by NIBR).