### PR TITLE
KNIME-1762: Bugfix for RDKit Structure Normalizer dialog layout on Mac

### DIFF
--- a/org.rdkit.knime.nodes/src/org/rdkit/knime/nodes/structurenormalizer/RDKitStructureNormalizerV2NodeDialog.java
+++ b/org.rdkit.knime.nodes/src/org/rdkit/knime/nodes/structurenormalizer/RDKitStructureNormalizerV2NodeDialog.java
@@ -48,6 +48,7 @@
  */
 package org.rdkit.knime.nodes.structurenormalizer;
 
+import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -227,7 +228,14 @@ public class RDKitStructureNormalizerV2NodeDialog extends DefaultNodeSettingsPan
             m_strLastInputColumnName = strNewInputColumnName;
         });
 
-		getTab("Options").setPreferredSize(new Dimension(600, 310));
+		final JPanel panelOptions = (JPanel) getTab("Options");
+		panelOptions.setBorder(
+				BorderFactory.createCompoundBorder(
+						BorderFactory.createEmptyBorder(15, 15, 15, 15),
+						panelOptions.getBorder()
+				)
+		);
+		panelOptions.setPreferredSize(new Dimension(880, 450));
 
 		createNewTab("Handling Failures");
 		createNewTab("Advanced");
@@ -434,23 +442,24 @@ public class RDKitStructureNormalizerV2NodeDialog extends DefaultNodeSettingsPan
 
 		// "Handling Failures" TAB
 		final JPanel panelFailures = (JPanel)getTab("Handling Failures");
-		panelFailures.setLayout(new GridBagLayout());
+		panelFailures.setLayout(new BorderLayout());
 		panelFailures.removeAll();
+		panelFailures.setBorder(
+				BorderFactory.createCompoundBorder(
+						BorderFactory.createEmptyBorder(15, 15, 15, 15),
+						panelFailures.getBorder()
+				)
+		);
 
 		final JPanel panelSubSpecialFailures = new JPanel(new GridBagLayout());
-		panelSubSpecialFailures.setPreferredSize(new Dimension(400, 200));
-
+		panelSubSpecialFailures.setPreferredSize(new Dimension(400, 250));
 		panelSubSpecialFailures.setBorder(BorderFactory.createTitledBorder("Special Failures (Optional)"));
 		LayoutUtils.constrain(panelSubSpecialFailures, compFailureCodes.getComponentPanel(),
 				0, 0, 1, LayoutUtils.REMAINDER,
 				LayoutUtils.BOTH, LayoutUtils.CENTER, 1.0d, 1.0d,
 				0, 10, 0, 7);
 
-		iRow = 0;
-		LayoutUtils.constrain(panelFailures, panelSubSpecialFailures,
-				0, iRow++, LayoutUtils.REMAINDER, LayoutUtils.REMAINDER,
-				LayoutUtils.BOTH, LayoutUtils.CENTER, 1.0d, 1.0d,
-				7, 7, 7, 7);
+		panelFailures.add(panelSubSpecialFailures, BorderLayout.NORTH);
 
 		LayoutUtils.correctKnimeDialogBorders(getPanel());
 	}


### PR DESCRIPTION
We found a layout bug that appeared on Mac and is fixed by the PR. This change is still part of the series of changes related to File Handling Framework integration.

@greglandrum, in case you want to skip the review of these little changes, let me know, then I will act as approver on NIBR side. I am reviewing anyway every work that is not done by me. If you like, we can make your review only mandatory when I write code myself and skip it otherwise.