### PR TITLE
Feature/issue 165 knime 5.9 update java and eclipse tycho

### DIFF
--- a/org.rdkit.knime.wizards/.classpath
+++ b/org.rdkit.knime.wizards/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/org.rdkit.knime.wizards/.settings/org.eclipse.jdt.core.prefs
+++ b/org.rdkit.knime.wizards/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=21

--- a/org.rdkit.knime.wizards/META-INF/MANIFEST.MF
+++ b/org.rdkit.knime.wizards/META-INF/MANIFEST.MF
@@ -19,7 +19,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.20.0,4.0.0)",
  org.eclipse.pde;bundle-version="[3.13.0,4.0.0)",
  org.apache.commons.commons-io;bundle-version="[2.15.1,3.0.0)", 
  jakarta.annotation-api;bundle-version="[2.1.1,3.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Export-Package: org.rdkit.knime.wizards

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
 	<properties>
 		<revision>5.2.1</revision>
 		<changelist>-SNAPSHOT</changelist>
-		<knime.version>5.5</knime.version>
-		<tycho.version>2.7.3</tycho.version>
+		<knime.version>nightly</knime.version>
+		<tycho.version>4.0.13</tycho.version>
 		<tycho.extras.version>${tycho.version}</tycho.extras.version>
 		<qualifier.prefix>v</qualifier.prefix>
 		<update.site>https://update.knime.com/analytics-platform/${knime.version}</update.site>
@@ -155,14 +155,21 @@
 				<!-- This plugin configuration block is only needed if the repository 
 					contains plug-ins that don't have any sources. If it is omitted Tycho will 
 					complain. -->
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-source-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>source-feature</id>
+						<id>plugin-source</id>
 						<phase>package</phase>
 						<goals>
-							<goal>source-feature</goal>
+							<goal>plugin-source</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>feature-source</id>
+						<phase>package</phase>
+						<goals>
+							<goal>feature-source</goal>
 						</goals>
 					</execution>
 				</executions>
@@ -185,9 +192,9 @@
 				<artifactId>tycho-packaging-plugin</artifactId>
 				<dependencies>
 					<dependency>
-						<groupId>org.eclipse.tycho.extras</groupId>
+						<groupId>org.eclipse.tycho</groupId>
 						<artifactId>tycho-buildtimestamp-jgit</artifactId>
-						<version>${tycho.extras.version}</version>
+						<version>${tycho.version}</version>
 					</dependency>
 				</dependencies>
 				<configuration>
@@ -234,19 +241,6 @@
 						</environment>
 					</environments>
 				</configuration>
-			</plugin>
-
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-source-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>plugin-source</id>
-						<goals>
-							<goal>plugin-source</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 
 			<!-- The following is required if source bundles are to be included -->


### PR DESCRIPTION
Fixes #165 

It's known and accepted that we currently link to KNIME AP `nightly` build. We will update the base reference as soon as 5.9 is out.